### PR TITLE
feat: add exception to prevent password reset for social login users

### DIFF
--- a/src/main/java/org/synergym/backendapi/dto/SocialSignupRequest.java
+++ b/src/main/java/org/synergym/backendapi/dto/SocialSignupRequest.java
@@ -24,4 +24,6 @@ public class SocialSignupRequest {
 
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate birthday;
+
+    private String provider;
 }

--- a/src/main/java/org/synergym/backendapi/entity/User.java
+++ b/src/main/java/org/synergym/backendapi/entity/User.java
@@ -47,8 +47,11 @@ public class User extends BaseEntity {
     @Column(name = "profile_image_content_type")
     private String profileImageContentType;
 
+    @Column(name = "provider")
+    private String provider;
+
     @Builder
-    public User(int id, String email, String password, String name, String goal, LocalDate birthday, String gender, Float weight, Float height, Role role) {
+    public User(int id, String email, String password, String name, String goal, LocalDate birthday, String gender, Float weight, Float height, Role role, String provider) {
         this.email = email;
         this.password = password;
         this.name = name;
@@ -58,6 +61,7 @@ public class User extends BaseEntity {
         this.weight = weight;
         this.height = height;
         this.role = role;
+        this.provider = provider;
     }
 
     public void updateEmail(String newEmail) {
@@ -86,5 +90,9 @@ public class User extends BaseEntity {
         this.profileImage = null;
         this.profileImageFileName = null;
         this.profileImageContentType = null;
+    }
+
+    public void updateProvider(String newProvider) {
+        this.provider = newProvider;
     }
 }

--- a/src/main/java/org/synergym/backendapi/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/org/synergym/backendapi/exception/handler/GlobalExceptionHandler.java
@@ -35,6 +35,11 @@ public class GlobalExceptionHandler {
         );
     }
 
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<String> handleIllegalStateException(IllegalStateException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleAllUncaughtException(Exception ex, WebRequest request) {
         log.error("Unhandled Exception: ", ex);

--- a/src/main/java/org/synergym/backendapi/service/AuthService.java
+++ b/src/main/java/org/synergym/backendapi/service/AuthService.java
@@ -31,6 +31,7 @@ public interface AuthService {
                 .weight(signupRequest.getWeight())
                 .height(signupRequest.getHeight())
                 .role(Role.MEMBER)
+                .provider("synergym")
                 .build();
     }
 }


### PR DESCRIPTION
- 소셜 로그인 사용자에 대해 비밀번호 재설정 요청 시 예외 처리 추가 / GlobalExceptionHandler에 적용
- User 엔티티에 provider 필드 활용 (e.g., LOCAL, GOOGLE, KAKAO)