### PR TITLE
feat(log): Modifying Exercise History Column and Modifying Page Inter…

### DIFF
--- a/src/main/java/org/synergym/backendapi/controller/ExerciseLogController.java
+++ b/src/main/java/org/synergym/backendapi/controller/ExerciseLogController.java
@@ -10,7 +10,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/exercise-logs")
+@RequestMapping("/api/logs")
 @RequiredArgsConstructor
 public class ExerciseLogController {
 
@@ -21,6 +21,12 @@ public class ExerciseLogController {
     public ResponseEntity<List<ExerciseLogDTO>> getAllExerciseLogs() {
         List<ExerciseLogDTO> logs = exerciseLogService.getAllExerciseLogs();
         return ResponseEntity.ok(logs);
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<Void> updateExerciseLog(@PathVariable int id, @RequestBody ExerciseLogDTO exerciseLogDTO) {
+        exerciseLogService.updateExerciseLog(id, exerciseLogDTO);
+        return ResponseEntity.ok().build();
     }
 
     // 운동기록 단건 조회

--- a/src/main/java/org/synergym/backendapi/dto/ExerciseLogRoutineDTO.java
+++ b/src/main/java/org/synergym/backendapi/dto/ExerciseLogRoutineDTO.java
@@ -13,4 +13,5 @@ public class ExerciseLogRoutineDTO {
     private int exerciseLogId;
     private int routineId;
     private String routineName;
-} 
+    private Character checkYn; // checkYn 필드 추가
+}

--- a/src/main/java/org/synergym/backendapi/dto/RoutineExerciseDTO.java
+++ b/src/main/java/org/synergym/backendapi/dto/RoutineExerciseDTO.java
@@ -16,5 +16,6 @@ public class RoutineExerciseDTO {
     private Integer exerciseId;
     private String exerciseName;
     private Integer order;
+    private Character checkYn;
 
 }

--- a/src/main/java/org/synergym/backendapi/entity/ExerciseLog.java
+++ b/src/main/java/org/synergym/backendapi/entity/ExerciseLog.java
@@ -26,7 +26,7 @@ public class ExerciseLog extends BaseEntity {
     @Column(name = "exercise_date", nullable = false)
     private LocalDate exerciseDate;
 
-    @Column(name = "completion_rate", nullable = false, precision = 3, scale = 2)
+    @Column(name = "completion_rate", nullable = false, precision = 5, scale = 2)
     private BigDecimal completionRate;
 
     @Column(name = "memo", columnDefinition = "TEXT")

--- a/src/main/java/org/synergym/backendapi/entity/ExerciseLogRoutine.java
+++ b/src/main/java/org/synergym/backendapi/entity/ExerciseLogRoutine.java
@@ -22,10 +22,22 @@ public class ExerciseLogRoutine {
     @JoinColumn(name = "routine_id")
     private Routine routine;
 
+    @Column(name = "check_yn", nullable = false, length = 1, columnDefinition = "CHAR(1)")
+    private Character checkYn;
+
     @Builder
     public ExerciseLogRoutine(ExerciseLog exerciseLog, Routine routine) {
         this.id = new ExerciseLogRoutineId(exerciseLog.getId(), routine.getId());
         this.exerciseLog = exerciseLog;
         this.routine = routine;
+        this.checkYn = 'N'; // '미완료' 상태로 기본값 설정
     }
-} 
+
+    /**
+     * 운동 완료 여부(checkYn)를 수정하는 메서드
+     * @param checkYn 'Y' 또는 'N'
+     */
+    public void updateCheckYn(Character checkYn) {
+        this.checkYn = checkYn;
+    }
+}

--- a/src/main/java/org/synergym/backendapi/entity/RoutineExercise.java
+++ b/src/main/java/org/synergym/backendapi/entity/RoutineExercise.java
@@ -28,12 +28,16 @@ public class RoutineExercise {
     @Column(name = "`order`", nullable = false)
     private int order;
 
+    @Column(name = "check_yn", nullable = false, length = 1, columnDefinition = "CHAR(1)")
+    private Character checkYn;
+
     @Builder
     public RoutineExercise(Routine routine, Exercise exercise, int order) {
         this.id = new RoutineExerciseId(routine.getId(), exercise.getId());
         this.routine = routine;
         this.exercise = exercise;
         this.order = order;
+        this.checkYn = 'N';
     }
 
     public void updateRoutine(Routine routine) {
@@ -46,5 +50,9 @@ public class RoutineExercise {
 
     public void updateOrder(int newOrder) {
         this.order = newOrder;
+    }
+
+    public void updateCheckYn(Character checkYn) {
+        this.checkYn = checkYn;
     }
 }

--- a/src/main/java/org/synergym/backendapi/service/ExerciseLogService.java
+++ b/src/main/java/org/synergym/backendapi/service/ExerciseLogService.java
@@ -23,6 +23,8 @@ public interface ExerciseLogService {
     // 사용자별 + 날짜별 운동기록 조회
     List<ExerciseLogDTO> getExerciseLogsByUserAndDate(Integer userId, LocalDate date);
 
+    void updateExerciseLog(Integer id, ExerciseLogDTO exerciseLogDTO);
+
     // 운동기록 삭제
     void deleteExerciseLog(Integer id);
 


### PR DESCRIPTION
- 운동 기록의 실시간 수정을 위한 `PATCH /api/logs/{id}` 엔드포인트
- `completion_rate` 컬럼의 데이터 타입을 `NUMERIC(5, 2)`로 변경하여, 100% 달성률 저장 시 발생하던 DB 오버플로우 오류를 해결
- 운동 기록 저장 시 달성률이 100%이면 `ExerciseLogRoutine`의 `checkYn`이 'Y'로 자동 설정되도록