### PR TITLE
feat: Add weekly and monthly exercise statistics API endpoints

### DIFF
--- a/src/main/java/org/synergym/backendapi/controller/ExerciseLogController.java
+++ b/src/main/java/org/synergym/backendapi/controller/ExerciseLogController.java
@@ -1,13 +1,23 @@
 package org.synergym.backendapi.controller;
 
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-import org.synergym.backendapi.dto.ExerciseLogDTO;
-import org.synergym.backendapi.service.ExerciseLogService;
-
 import java.time.LocalDate;
 import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.synergym.backendapi.dto.ExerciseLogDTO;
+import org.synergym.backendapi.dto.WeeklyMonthlyStats;
+import org.synergym.backendapi.service.ExerciseLogService;
+
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/logs")
@@ -66,4 +76,18 @@ public class ExerciseLogController {
         exerciseLogService.deleteExerciseLog(id);
         return ResponseEntity.noContent().build();
     }
-} 
+
+    // 사용자별 주간 통계 조회
+    @GetMapping("/user/{userId}/week")
+    public ResponseEntity<WeeklyMonthlyStats> getWeeklyStats(@PathVariable Integer userId) {
+        WeeklyMonthlyStats stats = exerciseLogService.getWeeklyStats(userId);
+        return ResponseEntity.ok(stats);
+    }
+
+    // 사용자별 월간 통계 조회
+    @GetMapping("/user/{userId}/month")
+    public ResponseEntity<WeeklyMonthlyStats> getMonthlyStats(@PathVariable Integer userId) {
+        WeeklyMonthlyStats stats = exerciseLogService.getMonthlyStats(userId);
+        return ResponseEntity.ok(stats);
+    }
+}

--- a/src/main/java/org/synergym/backendapi/dto/WeeklyMonthlyStats.java
+++ b/src/main/java/org/synergym/backendapi/dto/WeeklyMonthlyStats.java
@@ -1,0 +1,16 @@
+package org.synergym.backendapi.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class WeeklyMonthlyStats {
+    // 주간 통계
+    private Integer weeklyExerciseCount;
+    
+    // 월간 통계
+    private Integer monthlyExerciseCount;
+}

--- a/src/main/java/org/synergym/backendapi/repository/ExerciseLogRepository.java
+++ b/src/main/java/org/synergym/backendapi/repository/ExerciseLogRepository.java
@@ -1,13 +1,23 @@
 package org.synergym.backendapi.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.synergym.backendapi.entity.ExerciseLog;
-
 import java.time.LocalDate;
 import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.synergym.backendapi.entity.ExerciseLog;
 
 public interface ExerciseLogRepository extends JpaRepository<ExerciseLog, Integer> {
     
     // 날짜로 운동 기록 조회
     List<ExerciseLog> findByExerciseDate(LocalDate date);
+    
+    // 통계를 위한 쿼리 메서드들
+    @Query("SELECT COUNT(e) FROM ExerciseLog e WHERE e.user.id = :userId AND e.exerciseDate BETWEEN :startDate AND :endDate")
+    Integer countByUserIdAndDateBetween(@Param("userId") Integer userId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
+    
+    // 사용자별 운동 기록 조회 (날짜 범위)
+    @Query("SELECT e FROM ExerciseLog e WHERE e.user.id = :userId AND e.exerciseDate BETWEEN :startDate AND :endDate ORDER BY e.exerciseDate DESC")
+    List<ExerciseLog> findByUserIdAndDateBetween(@Param("userId") Integer userId, @Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
 }

--- a/src/main/java/org/synergym/backendapi/service/ExerciseLogService.java
+++ b/src/main/java/org/synergym/backendapi/service/ExerciseLogService.java
@@ -1,11 +1,13 @@
 package org.synergym.backendapi.service;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.synergym.backendapi.dto.ExerciseLogDTO;
+import org.synergym.backendapi.dto.WeeklyMonthlyStats;
 import org.synergym.backendapi.entity.ExerciseLog;
 import org.synergym.backendapi.entity.ExerciseLogRoutine;
-import java.util.List;
-import java.time.LocalDate;
-import java.util.stream.Collectors;
 
 public interface ExerciseLogService {
     // 운동기록 생성
@@ -27,6 +29,16 @@ public interface ExerciseLogService {
 
     // 운동기록 삭제
     void deleteExerciseLog(Integer id);
+
+    // 운동 통계 조회
+    WeeklyMonthlyStats getStats(Integer userId, LocalDate weekStart, LocalDate weekEnd, 
+                               LocalDate monthStart, LocalDate monthEnd);
+                               
+    // 주간 운동 통계 조회
+    WeeklyMonthlyStats getWeeklyStats(Integer userId);
+    
+    // 월간 운동 통계 조회
+    WeeklyMonthlyStats getMonthlyStats(Integer userId);
 
     // DTO -> Entity 변환 (ServiceImpl에서 반드시 활용)
     default ExerciseLog DTOtoEntity(ExerciseLogDTO dto) {
@@ -52,4 +64,4 @@ public interface ExerciseLogService {
                 .routineNames(logRoutines.stream().map(lr -> lr.getRoutine().getName()).collect(Collectors.toList()))
                 .build();
     }
-} 
+}

--- a/src/main/java/org/synergym/backendapi/service/ExerciseLogServiceImpl.java
+++ b/src/main/java/org/synergym/backendapi/service/ExerciseLogServiceImpl.java
@@ -1,26 +1,28 @@
 package org.synergym.backendapi.service;
 
-import lombok.RequiredArgsConstructor;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.synergym.backendapi.dto.ExerciseLogDTO;
+import org.synergym.backendapi.dto.WeeklyMonthlyStats;
 import org.synergym.backendapi.entity.ExerciseLog;
+import org.synergym.backendapi.entity.ExerciseLogRoutine;
 import org.synergym.backendapi.entity.Routine;
 import org.synergym.backendapi.entity.User;
-import org.synergym.backendapi.entity.ExerciseLogRoutine;
-
 import org.synergym.backendapi.exception.EntityNotFoundException;
 import org.synergym.backendapi.exception.ErrorCode;
 import org.synergym.backendapi.repository.ExerciseLogRepository;
+import org.synergym.backendapi.repository.ExerciseLogRoutineRepository;
 import org.synergym.backendapi.repository.RoutineRepository;
 import org.synergym.backendapi.repository.UserRepository;
-import org.synergym.backendapi.repository.ExerciseLogRoutineRepository;
 
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.ArrayList;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -113,7 +115,6 @@ public class ExerciseLogServiceImpl implements ExerciseLogService {
     @Override
     @Transactional(readOnly = true)
     public List<ExerciseLogDTO> getExerciseLogsByUser(Integer userId) {
-        User user = findUserById(userId);
         List<ExerciseLog> logs = exerciseLogRepository.findAll().stream()
                 .filter(log -> log.getUser() != null && Integer.valueOf(log.getUser().getId()).equals(userId))
                 .collect(Collectors.toList());
@@ -128,7 +129,6 @@ public class ExerciseLogServiceImpl implements ExerciseLogService {
     @Override
     @Transactional(readOnly = true)
     public List<ExerciseLogDTO> getExerciseLogsByUserAndDate(Integer userId, LocalDate date) {
-        User user = findUserById(userId);
         List<ExerciseLog> logs = exerciseLogRepository.findByExerciseDate(date).stream()
                 .filter(log -> log.getUser() != null && Integer.valueOf(log.getUser().getId()).equals(userId))
                 .collect(Collectors.toList());
@@ -149,4 +149,62 @@ public class ExerciseLogServiceImpl implements ExerciseLogService {
         exerciseLogRoutineRepository.deleteAll(logRoutines);
         exerciseLogRepository.delete(log);
     }
-} 
+
+    @Override
+    public WeeklyMonthlyStats getStats(Integer userId, LocalDate weekStart, LocalDate weekEnd, 
+                                      LocalDate monthStart, LocalDate monthEnd) {
+        // 주간 통계 조회
+        Integer weeklyCount = exerciseLogRepository.countByUserIdAndDateBetween(userId, weekStart, weekEnd);
+
+        // 월간 통계 조회
+        Integer monthlyCount = exerciseLogRepository.countByUserIdAndDateBetween(userId, monthStart, monthEnd);
+
+        // null 값 처리
+        weeklyCount = weeklyCount != null ? weeklyCount : 0;
+        
+        monthlyCount = monthlyCount != null ? monthlyCount : 0;
+
+        return new WeeklyMonthlyStats(
+            weeklyCount,
+            monthlyCount
+        );
+    }
+    
+    @Override
+    @Transactional(readOnly = true)
+    public WeeklyMonthlyStats getWeeklyStats(Integer userId) {
+        LocalDate today = LocalDate.now();
+        LocalDate weekStart = today.with(TemporalAdjusters.previousOrSame(java.time.DayOfWeek.MONDAY));
+        LocalDate weekEnd = today.with(TemporalAdjusters.nextOrSame(java.time.DayOfWeek.SUNDAY));
+        
+        // 주간 통계만 조회
+        Integer weeklyCount = exerciseLogRepository.countByUserIdAndDateBetween(userId, weekStart, weekEnd);
+        
+        // null 값 처리
+        weeklyCount = weeklyCount != null ? weeklyCount : 0;
+        
+        return new WeeklyMonthlyStats(
+            weeklyCount, // 주간 데이터
+            0
+        );
+    }
+    
+    @Override
+    @Transactional(readOnly = true)
+    public WeeklyMonthlyStats getMonthlyStats(Integer userId) {
+        LocalDate today = LocalDate.now();
+        LocalDate monthStart = today.with(TemporalAdjusters.firstDayOfMonth());
+        LocalDate monthEnd = today.with(TemporalAdjusters.lastDayOfMonth());
+        
+        // 월간 통계만 조회
+        Integer monthlyCount = exerciseLogRepository.countByUserIdAndDateBetween(userId, monthStart, monthEnd);
+        
+        // null 값 처리
+        monthlyCount = monthlyCount != null ? monthlyCount : 0;
+        
+        return new WeeklyMonthlyStats(
+            0,
+            monthlyCount
+        );
+    }
+}


### PR DESCRIPTION
- 주간 통계에 대한 /api/logs/user/{userId}/week 엔드포인트 추가
- 월별 통계에 대한 /api/logs/user/{userId}/month 엔드포인트 추가
- ExhibitLogService에서 getWeeklyStats() 및 getMonthlyStats() 구현
- ExerciseLogRepository findByUserIdAndDateBetween() 메서드 추가
- 지정된 기간 동안의 운동 횟수 반환
- 계산을 위해 현재 주(월요일-일요일)와 현재 월 사용