### PR TITLE
feat: Add like count and routine usage count to popular exercise endp…

### DIFF
--- a/src/main/java/org/synergym/backendapi/controller/ExerciseController.java
+++ b/src/main/java/org/synergym/backendapi/controller/ExerciseController.java
@@ -1,12 +1,20 @@
 package org.synergym.backendapi.controller;
 
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.synergym.backendapi.dto.ExerciseDTO;
 import org.synergym.backendapi.service.ExerciseService;
 
-import java.util.List;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/api/exercises")
@@ -55,5 +63,19 @@ public class ExerciseController {
     public ResponseEntity<Void> deleteExercise(@PathVariable int id) {
         exerciseService.deleteExercise(id);
         return ResponseEntity.noContent().build();
+    }
+
+    // 좋아요 수 기준 인기 운동 조회
+    @GetMapping("/popular/likes")
+    public ResponseEntity<List<ExerciseDTO>> getPopularExercisesByLikes(@RequestParam(defaultValue = "10") int limit) {
+        List<ExerciseDTO> exercises = exerciseService.getPopularExercisesByLikes(limit);
+        return ResponseEntity.ok(exercises);
+    }
+
+    // 루틴 사용 횟수 기준 인기 운동 조회
+    @GetMapping("/popular/routines")
+    public ResponseEntity<List<ExerciseDTO>> getPopularExercisesByRoutines(@RequestParam(defaultValue = "10") int limit) {
+        List<ExerciseDTO> exercises = exerciseService.getPopularExercisesByRoutines(limit);
+        return ResponseEntity.ok(exercises);
     }
 }

--- a/src/main/java/org/synergym/backendapi/dto/ExerciseDTO.java
+++ b/src/main/java/org/synergym/backendapi/dto/ExerciseDTO.java
@@ -27,4 +27,8 @@ public class ExerciseDTO {
     private String posture;  // 자세(선자세, 앉은자세, 누운자세)
     private String bodyPart;  // 부위 (camelCase로 수정)
     private String thumbnailUrl;  // 썸네일 url (camelCase로 수정)
+    
+    // 통계 필드 (인기 운동 조회 시 사용)
+    private Long likeCount;  // 좋아요 수
+    private Long routineCount;  // 루틴 사용 횟수
 }

--- a/src/main/java/org/synergym/backendapi/repository/ExerciseRepository.java
+++ b/src/main/java/org/synergym/backendapi/repository/ExerciseRepository.java
@@ -1,9 +1,11 @@
 package org.synergym.backendapi.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.synergym.backendapi.entity.Exercise;
-
 import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.synergym.backendapi.entity.Exercise;
 
 public interface ExerciseRepository extends JpaRepository<Exercise, Integer> {
     
@@ -12,4 +14,26 @@ public interface ExerciseRepository extends JpaRepository<Exercise, Integer> {
     
     // 운동 카테고리별 조회
     List<Exercise> findByCategory(String category);
+    
+    // 좋아요 수 기준 인기 운동 조회
+    @Query("SELECT e FROM Exercise e " +
+           "LEFT JOIN ExerciseLike el ON e.id = el.exercise.id " +
+           "GROUP BY e.id " +
+           "ORDER BY COUNT(el.exercise.id) DESC")
+    List<Exercise> findPopularExercisesByLikes(@Param("limit") int limit);
+    
+    // 루틴 사용 횟수 기준 인기 운동 조회
+    @Query("SELECT e FROM Exercise e " +
+           "LEFT JOIN RoutineExercise re ON e.id = re.exercise.id " +
+           "GROUP BY e.id " +
+           "ORDER BY COUNT(re.exercise.id) DESC")
+    List<Exercise> findPopularExercisesByRoutines(@Param("limit") int limit);
+    
+    // 특정 운동의 좋아요 수 조회
+    @Query("SELECT COUNT(el) FROM ExerciseLike el WHERE el.exercise.id = :exerciseId")
+    Long countLikesByExerciseId(@Param("exerciseId") Integer exerciseId);
+    
+    // 특정 운동의 루틴 사용 횟수 조회
+    @Query("SELECT COUNT(re) FROM RoutineExercise re WHERE re.exercise.id = :exerciseId")
+    Long countRoutinesByExerciseId(@Param("exerciseId") Integer exerciseId);
 }

--- a/src/main/java/org/synergym/backendapi/service/ExerciseService.java
+++ b/src/main/java/org/synergym/backendapi/service/ExerciseService.java
@@ -25,6 +25,12 @@ public interface ExerciseService {
     // 운동 카테고리별 조회
     List<ExerciseDTO> getExercisesByCategory(String category);
 
+    // 좋아요 수 기준 인기 운동 조회
+    List<ExerciseDTO> getPopularExercisesByLikes(int limit);
+
+    // 루틴 사용 횟수 기준 인기 운동 조회
+    List<ExerciseDTO> getPopularExercisesByRoutines(int limit);
+
     // DTO -> Entity 변환
     default Exercise DTOtoEntity(ExerciseDTO dto) {
         return Exercise.builder()
@@ -52,6 +58,25 @@ public interface ExerciseService {
                 .createdAt(exercise.getCreatedAt())
                 .updatedAt(exercise.getUpdatedAt())
                 .useYn(exercise.getUseYn())
+                .build();
+    }
+    
+    // Entity -> DTO 변환 (통계 정보 포함)
+    default ExerciseDTO entityToDTOWithStats(Exercise exercise, Long likeCount, Long routineCount) {
+        return ExerciseDTO.builder()
+                .id(exercise.getId())
+                .name(exercise.getName())
+                .category(exercise.getCategory())
+                .description(exercise.getDescription())
+                .difficulty(exercise.getDifficulty())
+                .posture(exercise.getPosture())
+                .bodyPart(exercise.getBodyPart())
+                .thumbnailUrl(exercise.getThumbnailUrl())
+                .createdAt(exercise.getCreatedAt())
+                .updatedAt(exercise.getUpdatedAt())
+                .useYn(exercise.getUseYn())
+                .likeCount(likeCount)
+                .routineCount(routineCount)
                 .build();
     }
 }

--- a/src/main/java/org/synergym/backendapi/service/ExerciseServiceImpl.java
+++ b/src/main/java/org/synergym/backendapi/service/ExerciseServiceImpl.java
@@ -1,6 +1,8 @@
 package org.synergym.backendapi.service;
 
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.synergym.backendapi.dto.ExerciseDTO;
@@ -9,8 +11,7 @@ import org.synergym.backendapi.exception.EntityNotFoundException;
 import org.synergym.backendapi.exception.ErrorCode;
 import org.synergym.backendapi.repository.ExerciseRepository;
 
-import java.util.List;
-import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
@@ -70,6 +71,34 @@ public class ExerciseServiceImpl implements ExerciseService {
         return exerciseRepository.findByCategory(category)
                 .stream()
                 .map(this::entityToDTO)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ExerciseDTO> getPopularExercisesByLikes(int limit) {
+        List<Exercise> exercises = exerciseRepository.findPopularExercisesByLikes(limit);
+        return exercises.stream()
+                .limit(limit)
+                .map(exercise -> {
+                    Long likeCount = exerciseRepository.countLikesByExerciseId(exercise.getId());
+                    Long routineCount = exerciseRepository.countRoutinesByExerciseId(exercise.getId());
+                    return entityToDTOWithStats(exercise, likeCount, routineCount);
+                })
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ExerciseDTO> getPopularExercisesByRoutines(int limit) {
+        List<Exercise> exercises = exerciseRepository.findPopularExercisesByRoutines(limit);
+        return exercises.stream()
+                .limit(limit)
+                .map(exercise -> {
+                    Long likeCount = exerciseRepository.countLikesByExerciseId(exercise.getId());
+                    Long routineCount = exerciseRepository.countRoutinesByExerciseId(exercise.getId());
+                    return entityToDTOWithStats(exercise, likeCount, routineCount);
+                })
                 .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
- **ExerciseDTO**: `likeCount`, `routineCount` 필드 추가
- **ExerciseRepository**: 개별 운동의 좋아요 수와 루틴 사용 횟수 조회 쿼리 추가
- **ExerciseService**: 통계 정보를 포함한 DTO 변환 메서드 추가
- **ExerciseServiceImpl**: 인기 운동 조회 시 통계 정보 포함하도록 수정

### 📋 API Endpoints
- `GET /api/exercises/popular/likes?limit={limit}` - 좋아요 수 기준 인기 운동
- `GET /api/exercises/popular/routines?limit={limit}` - 루틴 사용 횟수 기준 인기 운동