### PR TITLE
feat: add admin dashboard APIs, user management, and analysis stats

### DIFF
--- a/src/main/java/org/synergym/backendapi/controller/AdminController.java
+++ b/src/main/java/org/synergym/backendapi/controller/AdminController.java
@@ -1,0 +1,29 @@
+package org.synergym.backendapi.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.synergym.backendapi.dto.AdminDTO;
+import org.synergym.backendapi.service.AdminService;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @GetMapping("/dashboard")
+    public ResponseEntity<AdminDTO.DashboardResponse> getDashboardData() {
+        return ResponseEntity.ok(adminService.getDashboardData());
+    }
+
+    @GetMapping("/members")
+    public ResponseEntity<List<AdminDTO.MemberResponse>> getAllMembers() {
+        return ResponseEntity.ok(adminService.getAllMembers());
+    }
+}

--- a/src/main/java/org/synergym/backendapi/controller/UserController.java
+++ b/src/main/java/org/synergym/backendapi/controller/UserController.java
@@ -4,24 +4,22 @@ import java.io.IOException;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.temporal.TemporalAdjusters;
+import java.util.List;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.synergym.backendapi.dto.UserDTO;
 import org.synergym.backendapi.dto.WeeklyMonthlyStats;
 import org.synergym.backendapi.entity.User;
 import org.synergym.backendapi.service.ExerciseLogService;
 import org.synergym.backendapi.service.UserService;
+import org.synergym.backendapi.util.SecurityUtils;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,6 +32,11 @@ public class UserController {
 
     private final UserService userService;
     private final ExerciseLogService exerciseLogService;
+
+    @GetMapping
+    public ResponseEntity<List<UserDTO>> getAllUsers() {
+        return ResponseEntity.ok(userService.getAllUsers());
+    }
 
     @GetMapping("/{id}")
     public ResponseEntity<UserDTO> getUser(@PathVariable int id) {
@@ -58,6 +61,7 @@ public class UserController {
     }
 
     @GetMapping("/{id}/profile-image")
+    @Transactional(readOnly = true)
     public ResponseEntity<byte[]> getProfileImage(@PathVariable int id) {
         log.info(">>>>> getProfileImage 호출됨, 사용자 ID: {}", id);
 
@@ -102,5 +106,11 @@ public class UserController {
         WeeklyMonthlyStats stats = exerciseLogService.getStats(userId, weekStart, weekEnd, monthStart, monthEnd);
 
         return ResponseEntity.ok(stats);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteUser(@PathVariable int id) {
+        userService.deleteUserById(id);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/org/synergym/backendapi/dto/AdminDTO.java
+++ b/src/main/java/org/synergym/backendapi/dto/AdminDTO.java
@@ -1,0 +1,36 @@
+package org.synergym.backendapi.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class AdminDTO {
+
+    // 대시보드 전체 데이터를 담는 DTO
+    public record DashboardResponse(
+            StatsDto stats,
+            GenderAnalysisDto genderAnalysis,
+            List<AgeGroupAnalysisDTO> ageGroupAnalysis,
+            List<PopularExerciseDto> popularByLikes,
+            List<PopularExerciseDto> popularByRoutine
+    ) {
+        public record StatsDto(long totalMembers, long totalPosts, long totalAnalysis, WeeklyActiveUsersDto weeklyActiveUsers) {}
+        public record WeeklyActiveUsersDto(long value, double change) {}
+        public record GenderAnalysisDto(double male, double female, double maxScore) {}
+        public record PopularExerciseDto(String name, int count) {}
+
+        // 나이대별 분석 DTO
+        public record AgeGroupAnalysisDTO(String ageGroup, double averageScore) {}
+    }
+
+    // 회원 정보 DTO (관리자 페이지용)
+    public record MemberResponse(
+            int id,
+            String name,
+            String email,
+            LocalDate lastModified,
+            LocalDate signedUp,
+            String goal,
+            LocalDate birthDate,
+            String gender
+    ) {}
+}

--- a/src/main/java/org/synergym/backendapi/dto/UserDTO.java
+++ b/src/main/java/org/synergym/backendapi/dto/UserDTO.java
@@ -1,5 +1,6 @@
 package org.synergym.backendapi.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.*;
 import org.synergym.backendapi.entity.Role;
 
@@ -15,6 +16,7 @@ public class UserDTO {
     private int id;
     private String email;
     @ToString.Exclude
+    @JsonIgnore  // API 응답에서 비밀번호 제외
     private String password;
     private String name;
     private String goal;

--- a/src/main/java/org/synergym/backendapi/entity/User.java
+++ b/src/main/java/org/synergym/backendapi/entity/User.java
@@ -37,7 +37,9 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
 
-    @Column(name = "profile_image", columnDefinition = "BYTEA")
+    @Lob
+    @Basic(fetch = FetchType.LAZY)
+    @Column(name = "profile_image")
     private byte[] profileImage;
 
     @Column(name = "profile_image_file_name")

--- a/src/main/java/org/synergym/backendapi/repository/AnalysisHistoryRepository.java
+++ b/src/main/java/org/synergym/backendapi/repository/AnalysisHistoryRepository.java
@@ -1,10 +1,57 @@
 package org.synergym.backendapi.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.synergym.backendapi.entity.AnalysisHistory;
 
 import java.util.List;
 
 public interface AnalysisHistoryRepository extends JpaRepository<AnalysisHistory, Integer> {
     List<AnalysisHistory> findByUserIdOrderByCreatedAtDesc(int userId);
+
+    /**
+     * 성별에 따른 평균 분석 점수를 계산합니다.
+     * 각 분석 기록의 모든 부위 점수(5개)의 평균을 낸 뒤, 그 값들을 성별로 그룹화하여 다시 평균을 냅니다.
+     * @return Object 배열 리스트, 각 배열은 [String gender, Double averageScore] 형태입니다.
+     */
+    @Query("SELECT ah.user.gender, AVG((ah.spineCurvScore + ah.spineScolScore + ah.pelvicScore + ah.neckScore + ah.shoulderScore) / 5.0) " +
+            "FROM AnalysisHistory ah " +
+            "WHERE ah.user.gender IS NOT NULL " +
+            "GROUP BY ah.user.gender")
+    List<Object[]> findAverageScoreByGender();
+
+    /**
+     * 나이대별 평균 분석 점수를 계산합니다.
+     * 사용자의 생년월일을 기준으로 나이를 계산하고, 10대, 20대, 30대 등으로 그룹화합니다.
+     * @return Object 배열 리스트, 각 배열은 [String ageGroup, Double averageScore] 형태입니다.
+     */
+    @Query("SELECT " +
+            "  CASE " +
+            "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 20 THEN '10대' " +
+            "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 30 THEN '20대' " +
+            "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 40 THEN '30대' " +
+            "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 50 THEN '40대' " +
+            "    ELSE '50대 이상' " +
+            "  END, " + // <-- AS ageGroup 별칭은 SELECT 결과에서만 유효합니다.
+            "  AVG((ah.spineCurvScore + ah.spineScolScore + ah.pelvicScore + ah.neckScore + ah.shoulderScore) / 5.0) " +
+            "FROM AnalysisHistory ah JOIN ah.user u " +
+            "WHERE u.birthday IS NOT NULL " +
+            // ▼▼▼ GROUP BY와 ORDER BY에서 별칭 대신 CASE 표현식 전체를 사용 ▼▼▼
+            "GROUP BY " +
+            "  CASE " +
+            "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 20 THEN '10대' " +
+            "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 30 THEN '20대' " +
+            "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 40 THEN '30대' " +
+            "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 50 THEN '40대' " +
+            "    ELSE '50대 이상' " +
+            "  END " +
+            "ORDER BY " +
+            "  CASE " +
+            "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 20 THEN '10대' " +
+            "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 30 THEN '20대' " +
+            "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 40 THEN '30대' " +
+            "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 50 THEN '40대' " +
+            "    ELSE '50대 이상' " +
+            "  END")
+    List<Object[]> findAverageScoreByAgeGroup();
 }

--- a/src/main/java/org/synergym/backendapi/repository/UserRepository.java
+++ b/src/main/java/org/synergym/backendapi/repository/UserRepository.java
@@ -1,10 +1,13 @@
 package org.synergym.backendapi.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 import org.synergym.backendapi.entity.User;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -19,4 +22,19 @@ public interface UserRepository extends JpaRepository<User, Integer> {
 
     Optional<User> findByNameAndBirthday(String name, LocalDate birthday);
     Optional<User> findByEmailAndName(String email, String name);
+
+    /**
+     * 특정 날짜 이후에 활동(업데이트)한 사용자 수 조회
+     * @param date 기준 날짜
+     * @return 사용자 수
+     */
+    long countByUpdatedAtAfter(LocalDateTime date);
+
+    /**
+     * 두 날짜 사이에 활동(업데이트)한 사용자 수 조회
+     * @param start 시작 날짜
+     * @param end 종료 날짜
+     * @return 사용자 수
+     */
+    long countByUpdatedAtBetween(LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/org/synergym/backendapi/service/AdminService.java
+++ b/src/main/java/org/synergym/backendapi/service/AdminService.java
@@ -1,0 +1,9 @@
+package org.synergym.backendapi.service;
+
+import org.synergym.backendapi.dto.AdminDTO;
+import java.util.List;
+
+public interface AdminService {
+    AdminDTO.DashboardResponse getDashboardData();
+    List<AdminDTO.MemberResponse> getAllMembers();
+}

--- a/src/main/java/org/synergym/backendapi/service/AdminServiceImpl.java
+++ b/src/main/java/org/synergym/backendapi/service/AdminServiceImpl.java
@@ -1,0 +1,130 @@
+package org.synergym.backendapi.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.synergym.backendapi.dto.AdminDTO;
+import org.synergym.backendapi.dto.ExerciseDTO;
+import org.synergym.backendapi.entity.User;
+import org.synergym.backendapi.repository.AnalysisHistoryRepository;
+import org.synergym.backendapi.repository.CategoryRepository;
+import org.synergym.backendapi.repository.PostRepository;
+import org.synergym.backendapi.repository.UserRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AdminServiceImpl implements AdminService {
+
+    // Repository 및 신규 Service 의존성 주입
+    private final UserRepository userRepository;
+    private final PostRepository postRepository;
+    private final AnalysisHistoryRepository analysisHistoryRepository;
+    private final ExerciseService exerciseService;
+
+    @Override
+    public AdminDTO.DashboardResponse getDashboardData() {
+        // --- 1. 기본 통계 (Stats) 계산 ---
+        long totalMembers = userRepository.count();
+        long totalPosts = postRepository.count();
+        // '총 분석 횟수'는 AnalysisHistory 테이블의 전체 레코드 수로 계산
+        long totalAnalysis = analysisHistoryRepository.count();
+
+        // 주간 활성 사용자 계산 (기존 로직 유지)
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime oneWeekAgo = now.minusWeeks(1);
+        LocalDateTime twoWeeksAgo = now.minusWeeks(2);
+        long currentWeekActiveUsers = userRepository.countByUpdatedAtAfter(oneWeekAgo);
+        long previousWeekActiveUsers = userRepository.countByUpdatedAtBetween(twoWeeksAgo, oneWeekAgo);
+        double weeklyChange = (previousWeekActiveUsers > 0) ? ((double) (currentWeekActiveUsers - previousWeekActiveUsers) / previousWeekActiveUsers) * 100 : 0.0;
+
+        AdminDTO.DashboardResponse.StatsDto stats = new AdminDTO.DashboardResponse.StatsDto(
+                totalMembers, totalPosts, totalAnalysis,
+                new AdminDTO.DashboardResponse.WeeklyActiveUsersDto(currentWeekActiveUsers, Double.parseDouble(String.format("%.1f", weeklyChange)))
+        );
+
+        // --- 2. 성별 분석 점수 계산 (개선된 버전) ---
+        // Repository에서 성별 평균 점수 데이터를 직접 조회
+        List<Object[]> results = analysisHistoryRepository.findAverageScoreByGender();
+
+        results.forEach(r -> log.info("  - 성별: {}, 평균 점수: {}", r[0], r[1]));
+
+        Map<String, Double> averageScoresByGender = results.stream()
+                .collect(Collectors.toMap(
+                        result -> (String) result[0],
+                        result -> (Double) result[1]
+                ));
+
+        // getOrDefault로 안전하게 값 조회
+        double maleAverageScore = averageScoresByGender.getOrDefault("MALE", 0.0);
+        double femaleAverageScore = averageScoresByGender.getOrDefault("FEMALE", 0.0);
+
+        // DTO 생성 시, 바로 반올림하여 할당
+        AdminDTO.DashboardResponse.GenderAnalysisDto genderAnalysis = new AdminDTO.DashboardResponse.GenderAnalysisDto(
+                roundToOneDecimal(maleAverageScore),   // 반올림 헬퍼 메소드 사용
+                roundToOneDecimal(femaleAverageScore),  // 반올림 헬퍼 메소드 사용
+                100.0 // 점수는 100점 만점으로 가정
+        );
+
+        // --- 2.1. 나이대별 분석 점수 계산 ---
+        List<AdminDTO.DashboardResponse.AgeGroupAnalysisDTO> ageGroupAnalysis =
+                analysisHistoryRepository.findAverageScoreByAgeGroup().stream()
+                        .map(result -> new AdminDTO.DashboardResponse.AgeGroupAnalysisDTO(
+                                (String) result[0], // ageGroup (e.g., "20대")
+                                Double.parseDouble(String.format("%.1f", (Double) result[1])) // averageScore
+                        ))
+                        .collect(Collectors.toList());
+
+        // --- 3. 인기 운동 데이터 조회 ---
+        // 주입받은 ExerciseService의 메소드를 직접 호출
+        List<ExerciseDTO> likesTop3 = exerciseService.getPopularExercisesByLikes(250);
+        List<ExerciseDTO> routinesTop3 = exerciseService.getPopularExercisesByRoutines(250);
+
+        // ExerciseDTO를 Dashboard DTO로 변환
+        List<AdminDTO.DashboardResponse.PopularExerciseDto> popularByLikes = likesTop3.stream()
+                .map(e -> new AdminDTO.DashboardResponse.PopularExerciseDto(e.getName(), e.getLikeCount().intValue()))
+                .collect(Collectors.toList());
+
+        List<AdminDTO.DashboardResponse.PopularExerciseDto> popularByRoutine = routinesTop3.stream()
+                .map(e -> new AdminDTO.DashboardResponse.PopularExerciseDto(e.getName(), e.getRoutineCount().intValue()))
+                .collect(Collectors.toList());
+
+        return new AdminDTO.DashboardResponse(stats, genderAnalysis, ageGroupAnalysis, popularByLikes, popularByRoutine);
+    }
+
+    @Override
+    public List<AdminDTO.MemberResponse> getAllMembers() {
+        return userRepository.findAll().stream()
+                .map(this::toMemberResponse)
+                .collect(Collectors.toList());
+    }
+
+    // --- Entity to DTO 변환 헬퍼 메소드 ---
+
+    private AdminDTO.MemberResponse toMemberResponse(User user) {
+        return new AdminDTO.MemberResponse(
+                user.getId(),
+                user.getName(),
+                user.getEmail(),
+                user.getUpdatedAt().toLocalDate(),
+                user.getCreatedAt().toLocalDate(),
+                user.getGoal(),
+                user.getBirthday(),
+                user.getGender()
+        );
+    }
+
+    /**
+     * double 값을 소수점 첫째 자리까지 반올림하는 헬퍼 메소드
+     * @param value 반올림할 값
+     * @return 반올림된 값
+     */
+    private double roundToOneDecimal(double value) {
+        return Math.round(value * 10.0) / 10.0;
+    }
+}

--- a/src/main/java/org/synergym/backendapi/service/PostServiceImpl.java
+++ b/src/main/java/org/synergym/backendapi/service/PostServiceImpl.java
@@ -149,8 +149,9 @@ public class PostServiceImpl implements PostService {
     @Override
     @Transactional
     public void deletePost(Integer id) {
-        Post post = findPostById(id);
-        postRepository.delete(post);
+        Post post = postRepository.findById(id)
+                        .orElseThrow(() -> new EntityNotFoundException(ErrorCode.POST_NOT_FOUND));
+        post.softDelete();
     }
 
     @Override

--- a/src/main/java/org/synergym/backendapi/service/UserServiceImpl.java
+++ b/src/main/java/org/synergym/backendapi/service/UserServiceImpl.java
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-import org.synergym.backendapi.dto.ChangePasswordRequest;
 import org.synergym.backendapi.dto.UserDTO;
 import org.synergym.backendapi.entity.User;
 import org.synergym.backendapi.exception.EntityNotFoundException;
@@ -13,7 +12,6 @@ import org.synergym.backendapi.repository.UserRepository;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -77,8 +75,10 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public void deleteUserById(int id) {
-        User user = findUserById(id);
-        userRepository.delete(user);
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+
+        user.softDelete();
     }
 
 


### PR DESCRIPTION
사용자 관리
- UserController: 전체 사용자 조회, 사용자 삭제(소프트 삭제) API 추가
- UserDTO: 비밀번호 필드에 @JsonIgnore 적용
- User 엔티티: 프로필 이미지 @Lob 및 LAZY 로딩 설정
- UserRepository: 활성 사용자 수, 날짜별 사용자 통계 메서드 추가
- UserServiceImpl: 사용자 삭제 시 소프트 삭제로 변경, 불필요한 import 제거

관리자 기능
- AdminController: 관리자 대시보드 및 회원 목록 조회 API 추가
- AdminDTO: 대시보드 응답 및 회원 정보 DTO 정의
- AdminService / AdminServiceImpl: 대시보드 통계, 성별·나이대별 분석 점수, 인기 운동 데이터 조회 구현

데이터 분석
- AnalysisHistoryRepository: 성별/나이대별 평균 분석 점수 조회 쿼리 추가

게시글 관리
- PostServiceImpl: 게시글 삭제 시 소프트 삭제로 변경