### PR TITLE
feat: Extend admin dashboard with analysis distribution features

### DIFF
--- a/src/main/java/org/synergym/backendapi/controller/AdminController.java
+++ b/src/main/java/org/synergym/backendapi/controller/AdminController.java
@@ -1,8 +1,7 @@
 package org.synergym.backendapi.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.http.HttpStatus;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.synergym.backendapi.dto.AdminDTO;
@@ -10,6 +9,7 @@ import org.synergym.backendapi.service.AdminService;
 
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/admin")
@@ -26,4 +26,15 @@ public class AdminController {
     public ResponseEntity<List<AdminDTO.MemberResponse>> getAllMembers() {
         return ResponseEntity.ok(adminService.getAllMembers());
     }
+
+    @GetMapping("/analysis-distribution")
+    public ResponseEntity<AdminDTO.DashboardResponse.AnalysisDistributionResponse> getAnalysisDistribution() {
+        // [디버깅] API 호출 시작 로그
+        log.info("✅✅✅ /api/admin/test 엔드포인트가 성공적으로 호출되었습니다! ✅✅✅");
+
+        AdminDTO.DashboardResponse.AnalysisDistributionResponse response = adminService.getAnalysisDistributionData();
+
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/org/synergym/backendapi/dto/AdminDTO.java
+++ b/src/main/java/org/synergym/backendapi/dto/AdminDTO.java
@@ -1,5 +1,9 @@
 package org.synergym.backendapi.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
 import java.time.LocalDate;
 import java.util.List;
 
@@ -18,12 +22,17 @@ public class AdminDTO {
     ) {
         public record StatsDto(long totalMembers, long totalPosts, long totalAnalysis, WeeklyActiveUsersDto weeklyActiveUsers) {}
         public record WeeklyActiveUsersDto(long value, double change) {}
-        public record GenderAnalysisDto(double male, double female, double maxScore) {}
+        public record GenderAnalysisDto(double male, double female, double maxScore, long maleCount, long femaleCount) {}
         public record PopularExerciseDto(String name, int count) {}
 
         // 나이대별 분석 DTO
-        public record AgeGroupAnalysisDTO(String ageGroup, double averageScore) {}
-        
+        public record AgeGroupAnalysisDTO(String ageGroup, double averageScore, long count) {}
+
+        public record GenderDistribution(String gender, String analysisCount, int userCount){}
+        public record AgeGroupDistribution(String ageGroup, String analysisCount, int userCount){}
+
+        public record AnalysisDistributionResponse(List<DashboardResponse.GenderDistribution> genderDistribution, List<AgeGroupDistribution> ageGroupDistribution){}
+
         // 인기 게시글 DTO
         public record PopularPostDto(String title, int count, String categoryName, int postId) {}
     }

--- a/src/main/java/org/synergym/backendapi/repository/AnalysisHistoryRepository.java
+++ b/src/main/java/org/synergym/backendapi/repository/AnalysisHistoryRepository.java
@@ -7,6 +7,7 @@ import org.synergym.backendapi.entity.AnalysisHistory;
 import java.util.List;
 
 public interface AnalysisHistoryRepository extends JpaRepository<AnalysisHistory, Integer> {
+
     List<AnalysisHistory> findByUserIdOrderByCreatedAtDesc(int userId);
 
     /**
@@ -32,11 +33,10 @@ public interface AnalysisHistoryRepository extends JpaRepository<AnalysisHistory
             "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 40 THEN '30대' " +
             "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 50 THEN '40대' " +
             "    ELSE '50대 이상' " +
-            "  END, " + // <-- AS ageGroup 별칭은 SELECT 결과에서만 유효합니다.
+            "  END, " +
             "  AVG((ah.spineCurvScore + ah.spineScolScore + ah.pelvicScore + ah.neckScore + ah.shoulderScore) / 5.0) " +
             "FROM AnalysisHistory ah JOIN ah.user u " +
             "WHERE u.birthday IS NOT NULL " +
-            // ▼▼▼ GROUP BY와 ORDER BY에서 별칭 대신 CASE 표현식 전체를 사용 ▼▼▼
             "GROUP BY " +
             "  CASE " +
             "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 20 THEN '10대' " +
@@ -54,4 +54,122 @@ public interface AnalysisHistoryRepository extends JpaRepository<AnalysisHistory
             "    ELSE '50대 이상' " +
             "  END")
     List<Object[]> findAverageScoreByAgeGroup();
+
+    /**
+     * 성별에 따른 총 분석 횟수를 계산합니다.
+     * @return Object 배열 리스트, 각 배열은 [String gender, Long count] 형태입니다.
+     */
+    @Query("SELECT ah.user.gender, COUNT(ah) " +
+            "FROM AnalysisHistory ah " +
+            "WHERE ah.user.gender IS NOT NULL " +
+            "GROUP BY ah.user.gender")
+    List<Object[]> countByGender();
+
+    /**
+     * 나이대별 총 분석 횟수를 계산합니다.
+     * @return Object 배열 리스트, 각 배열은 [String ageGroup, Long count] 형태입니다.
+     */
+    @Query("SELECT " +
+            "  CASE " +
+            "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 20 THEN '10대' " +
+            "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 30 THEN '20대' " +
+            "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 40 THEN '30대' " +
+            "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 50 THEN '40대' " +
+            "    ELSE '50대 이상' " +
+            "  END, " +
+            "  COUNT(ah) " +
+            "FROM AnalysisHistory ah JOIN ah.user u " +
+            "WHERE u.birthday IS NOT NULL " +
+            "GROUP BY " +
+            "  CASE " +
+            "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 20 THEN '10대' " +
+            "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 30 THEN '20대' " +
+            "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 40 THEN '30대' " +
+            "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 50 THEN '40대' " +
+            "    ELSE '50대 이상' " +
+            "  END " +
+            "ORDER BY " +
+            "  CASE " +
+            "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 20 THEN '10대' " +
+            "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 30 THEN '20대' " +
+            "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 40 THEN '30대' " +
+            "    WHEN (YEAR(CURRENT_DATE) - YEAR(u.birthday)) < 50 THEN '40대' " +
+            "    ELSE '50대 이상' " +
+            "  END")
+    List<Object[]> countByAgeGroup();
+
+    @Query(
+            value = "WITH user_analysis AS ( " +
+                    "  SELECT " +
+                    "    u.user_id, " +
+                    "    u.gender, " +
+                    "    COUNT(a.analysis_id) AS analysis_count " +
+                    "  FROM Users u " +
+                    "  LEFT JOIN Analysis_History a ON u.user_id = a.user_id " +
+                    "  WHERE u.gender IS NOT NULL " +
+                    "  GROUP BY u.user_id, u.gender " +
+                    ") " +
+                    "SELECT " +
+                    "  CASE " +
+                    "    WHEN analysis_count = 0 THEN '0회' " +
+                    "    WHEN analysis_count = 1 THEN '1회' " +
+                    "    WHEN analysis_count = 2 THEN '2회' " +
+                    "    ELSE '3회 이상' " +
+                    "  END AS analysis_count_group, " +
+                    "  gender, " +
+                    "  COUNT(*) AS user_count " +
+                    "FROM user_analysis " +
+                    // ▼▼▼ GROUP BY 절에 analysis_count를 추가합니다.
+                    "GROUP BY analysis_count, gender " +
+                    "ORDER BY " +
+                    "  CASE " +
+                    "    WHEN analysis_count = 0 THEN 0 " +
+                    "    WHEN analysis_count = 1 THEN 1 " +
+                    "    WHEN analysis_count = 2 THEN 2 " +
+                    "    ELSE 3 " +
+                    "  END, " +
+                    "  gender",
+            nativeQuery = true
+    )
+    List<Object[]> findUserCountByAnalysisCountPerGender();
+
+    @Query(
+            value = "WITH user_analysis AS ( " +
+                    "  SELECT " +
+                    "    u.user_id, " +
+                    "    CASE " +
+                    "      WHEN (EXTRACT(YEAR FROM CURRENT_DATE) - EXTRACT(YEAR FROM u.birthday)) < 20 THEN '10대' " +
+                    "      WHEN (EXTRACT(YEAR FROM CURRENT_DATE) - EXTRACT(YEAR FROM u.birthday)) < 30 THEN '20대' " +
+                    "      WHEN (EXTRACT(YEAR FROM CURRENT_DATE) - EXTRACT(YEAR FROM u.birthday)) < 40 THEN '30대' " +
+                    "      WHEN (EXTRACT(YEAR FROM CURRENT_DATE) - EXTRACT(YEAR FROM u.birthday)) < 50 THEN '40대' " +
+                    "      ELSE '50대 이상' " +
+                    "    END AS age_group, " +
+                    "    COUNT(a.analysis_id) AS analysis_count " +
+                    "  FROM Users u " +
+                    "  LEFT JOIN Analysis_History a ON u.user_id = a.user_id " +
+                    "  WHERE u.birthday IS NOT NULL " +
+                    "  GROUP BY u.user_id, age_group " +
+                    ") " +
+                    "SELECT " +
+                    "  CASE " +
+                    "    WHEN analysis_count = 0 THEN '0회' " +
+                    "    WHEN analysis_count = 1 THEN '1회' " +
+                    "    WHEN analysis_count = 2 THEN '2회' " +
+                    "    ELSE '3회 이상' " +
+                    "  END AS analysis_count_group, " +
+                    "  age_group, " +
+                    "  COUNT(*) AS user_count " +
+                    "FROM user_analysis " +
+                    "GROUP BY analysis_count, age_group " +
+                    "ORDER BY " +
+                    "  CASE " +
+                    "    WHEN analysis_count = 0 THEN 0 " +
+                    "    WHEN analysis_count = 1 THEN 1 " +
+                    "    WHEN analysis_count = 2 THEN 2 " +
+                    "    ELSE 3 " +
+                    "  END, " +
+                    "  age_group",
+            nativeQuery = true
+    )
+    List<Object[]> findUserCountByAnalysisCountPerAgeGroup();
 }

--- a/src/main/java/org/synergym/backendapi/service/AdminService.java
+++ b/src/main/java/org/synergym/backendapi/service/AdminService.java
@@ -6,4 +6,5 @@ import java.util.List;
 public interface AdminService {
     AdminDTO.DashboardResponse getDashboardData();
     List<AdminDTO.MemberResponse> getAllMembers();
+    AdminDTO.DashboardResponse.AnalysisDistributionResponse getAnalysisDistributionData();
 }


### PR DESCRIPTION
### DTO 확장

* `AdminDTO`

  * 성별 분석 DTO에 `maleCount`, `femaleCount` 필드 추가
  * 나이대별 분석 DTO에 `count` 필드 추가
* 새로운 분석 분포 응답용 DTO 추가

  * `GenderDistribution` : 성별별 분석 횟수 분포
  * `AgeGroupDistribution` : 나이대별 분석 횟수 분포
  * `AnalysisDistributionResponse` : 통합 응답

---

### Repository

* `AnalysisHistoryRepository`

  * `countByGender()` : 성별별 총 분석 횟수 조회
  * `countByAgeGroup()` : 나이대별 총 분석 횟수 조회
  * 네이티브 SQL로 복잡한 분포 쿼리 구현

    * `findUserCountByAnalysisCountPerGender()`
    * `findUserCountByAnalysisCountPerAgeGroup()`

---

### Service

* `AdminService`

  * 분석 분포 데이터 조회 메소드 추가
* `AdminServiceImpl`

  * 기존 대시보드 데이터에 분석 횟수 통합
  * 새로운 분석 분포 데이터 처리 로직 구현
  * 타입 안전성을 위한 `safeCastToInt()` 헬퍼 메소드 추가
  * 상세 디버깅 로그 추가

---

### Controller

* `AdminController`

  * `/api/admin/analysis-distribution` 엔드포인트 추가
