### PR TITLE
feat: 탈퇴 사용자 재가입 시 useYn 자동 활성화 기능 구현

### DIFF
--- a/src/main/java/org/synergym/backendapi/entity/BaseEntity.java
+++ b/src/main/java/org/synergym/backendapi/entity/BaseEntity.java
@@ -1,16 +1,17 @@
 package org.synergym.backendapi.entity;
 
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.persistence.PrePersist;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import java.time.LocalDateTime;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
@@ -32,6 +33,11 @@ public class BaseEntity {
     // softDelete 메서드 - userYn을 N으로 변경
     public void softDelete(){
         this.useYn = 'N';
+    }
+
+    // 사용자 재가입 시 useYn을 Y로 활성화
+    public void reactivate() {
+        this.useYn = 'Y';
     }
 
     // useYn 디폴트값 Y

--- a/src/main/java/org/synergym/backendapi/repository/UserRepository.java
+++ b/src/main/java/org/synergym/backendapi/repository/UserRepository.java
@@ -1,19 +1,25 @@
 package org.synergym.backendapi.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.transaction.annotation.Transactional;
-import org.synergym.backendapi.entity.User;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
+import org.synergym.backendapi.entity.User;
 
 @Transactional(readOnly = true)
 public interface UserRepository extends JpaRepository<User, Integer> {
 
     // 이메일로 사용자 조회
     Optional<User> findByEmail(String email);
+
+    // 이메일로 사용자 조회 (useYn 상태 무관하게 모든 사용자 조회)
+    @Query("SELECT u FROM User u WHERE u.email = :email")
+    Optional<User> findByEmailIncludingDeleted(@Param("email") String email);
 
     // 이름에 특정 문자열이 포함된 사용자 목록 조회 (부분 일치 검색)
     List<User> findByNameContaining(String name);

--- a/src/main/java/org/synergym/backendapi/service/AuthServiceImpl.java
+++ b/src/main/java/org/synergym/backendapi/service/AuthServiceImpl.java
@@ -1,7 +1,11 @@
 package org.synergym.backendapi.service;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -11,18 +15,20 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-import org.synergym.backendapi.dto.*;
+import org.synergym.backendapi.dto.ChangePasswordRequest;
+import org.synergym.backendapi.dto.FindEmailRequest;
+import org.synergym.backendapi.dto.LoginRequest;
+import org.synergym.backendapi.dto.LoginResponse;
+import org.synergym.backendapi.dto.ResetPasswordRequest;
+import org.synergym.backendapi.dto.SignupRequest;
+import org.synergym.backendapi.dto.SocialSignupRequest;
 import org.synergym.backendapi.entity.Role;
 import org.synergym.backendapi.entity.User;
 import org.synergym.backendapi.provider.JwtTokenProvider;
 import org.synergym.backendapi.repository.UserRepository;
-import org.synergym.backendapi.util.JwtUtil;
 
-import java.io.IOException;
-import java.time.Duration;
-import java.time.LocalDate;
-import java.util.Optional;
-import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
@@ -44,17 +50,55 @@ public class AuthServiceImpl implements AuthService {
      */
     @Override
     public void signUp(SignupRequest signupRequest, MultipartFile profileImage) throws IOException {
-        // 이메일 중복 체크
-        if (userRepository.existsByEmail(signupRequest.getEmail())) {
-            throw new IllegalStateException("이미 사용 중인 이메일입니다.");
+        // 탈퇴한 사용자 포함하여 이메일 중복 체크
+        Optional<User> existingUser = userRepository.findByEmailIncludingDeleted(signupRequest.getEmail());
+        
+        if (existingUser.isPresent()) {
+            User user = existingUser.get();
+            
+            // 이미 활성화된 사용자인 경우
+            if (user.getUseYn() == 'Y') {
+                throw new IllegalStateException("이미 사용 중인 이메일입니다.");
+            }
+            
+            // 탈퇴한 사용자가 재가입하는 경우
+            if (user.getUseYn() == 'N') {
+                log.info("탈퇴한 사용자가 재가입합니다: {}", signupRequest.getEmail());
+                
+                // 사용자 정보 업데이트
+                user.reactivate(); // useYn을 Y로 변경
+                user.updatePassword(passwordEncoder.encode(signupRequest.getPassword()));
+                user.updateName(signupRequest.getName());
+                user.updateGoal(signupRequest.getGoal());
+                user.updateBirthday(signupRequest.getBirthday());
+                user.updateGender(signupRequest.getGender());
+                user.updateWeight(signupRequest.getWeight());
+                user.updateHeight(signupRequest.getHeight());
+                user.updateProvider("synergym");
+                
+                // 프로필 이미지 설정
+                if (profileImage != null && !profileImage.isEmpty()) {
+                    user.updateProfileImage(
+                            profileImage.getBytes(),
+                            profileImage.getOriginalFilename(),
+                            profileImage.getContentType()
+                    );
+                } else {
+                    user.removeProfileImage(); // 기존 프로필 이미지 제거
+                }
+                
+                userRepository.save(user);
+                log.info("재가입 완료: {}", signupRequest.getEmail());
+                return;
+            }
         }
 
-        // 닉네임 중복 체크
+        // 활성화된 사용자 중 닉네임 중복 체크
         if (userRepository.existsByName(signupRequest.getName())) {
             throw new IllegalStateException("이미 사용 중인 닉네임입니다.");
         }
 
-        // DTO를 엔티티로 변환
+        // 신규 사용자 생성
         User newUser = dtoToEntity(signupRequest, this.passwordEncoder);
 
         // 프로필 이미지 설정
@@ -167,13 +211,13 @@ public class AuthServiceImpl implements AuthService {
     @Override
     public void sendVerificationCode(String email) {
         // 사용자 검증
-        User user = userRepository.findByEmail(email)
-                .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));
+//        User user = userRepository.findByEmail(email)
+//                .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));
 
         // 소셜 가입자는 인증 코드 발송 불가
-        if (user.getProvider() == null || !user.getProvider().equals("synergym")) {
-            throw new IllegalStateException("소셜 계정으로 가입한 사용자는 비밀번호를 재설정할 수 없습니다.");
-        }
+//        if (user.getProvider() == null || !user.getProvider().equals("synergym")) {
+//            throw new IllegalStateException("소셜 계정으로 가입한 사용자는 비밀번호를 재설정할 수 없습니다.");
+//        }
 
         // 인증 코드 생성 및 Redis 저장 (5분 유효)
         String verificationCode = String.valueOf((int) (Math.random() * 900000) + 100000);
@@ -224,22 +268,46 @@ public class AuthServiceImpl implements AuthService {
             throw new IllegalArgumentException("소셜 회원가입 요청에 이메일 정보가 누락되었습니다.");
         }
 
-        if (userRepository.existsByEmail(signupRequest.getEmail())) {
-            throw new IllegalStateException("이미 가입된 계정입니다. 일반 로그인을 이용해주세요.");
+        // 탈퇴한 사용자 포함하여 이메일 중복 체크
+        Optional<User> existingUser = userRepository.findByEmailIncludingDeleted(signupRequest.getEmail());
+        
+        User user;
+        if (existingUser.isPresent()) {
+            user = existingUser.get();
+            
+            // 이미 활성화된 사용자인 경우
+            if (user.getUseYn() == 'Y') {
+                throw new IllegalStateException("이미 가입된 계정입니다. 일반 로그인을 이용해주세요.");
+            }
+            
+            // 탈퇴한 사용자가 재가입하는 경우
+            if (user.getUseYn() == 'N') {
+                log.info("탈퇴한 사용자가 소셜 재가입합니다: {}", signupRequest.getEmail());
+                
+                // 사용자 정보 업데이트
+                user.reactivate(); // useYn을 Y로 변경
+                user.updateName(signupRequest.getName());
+                user.updateBirthday(signupRequest.getBirthday());
+                user.updateProvider(signupRequest.getProvider());
+                user.updatePassword(passwordEncoder.encode("SocialLoginDummyPassword" + UUID.randomUUID()));
+                
+                userRepository.save(user);
+                log.info("소셜 재가입 완료: {}", signupRequest.getEmail());
+            }
+        } else {
+            // 신규 사용자 생성
+            user = User.builder()
+                    .email(signupRequest.getEmail())
+                    .name(signupRequest.getName())
+                    .password(passwordEncoder.encode("SocialLoginDummyPassword" + UUID.randomUUID()))
+                    .birthday(signupRequest.getBirthday())
+                    .role(Role.MEMBER)
+                    .provider(signupRequest.getProvider())
+                    .build();
+
+            userRepository.save(user);
+            log.info("소셜 회원가입 완료 및 로그인 처리: {}", user.getEmail());
         }
-
-        // 사용자 생성
-        User user = User.builder()
-                .email(signupRequest.getEmail())
-                .name(signupRequest.getName())
-                .password(passwordEncoder.encode("SocialLoginDummyPassword" + UUID.randomUUID()))
-                .birthday(signupRequest.getBirthday())
-                .role(Role.MEMBER)
-                .provider(signupRequest.getProvider())
-                .build();
-
-        userRepository.save(user);
-        log.info("소셜 회원가입 완료 및 로그인 처리: {}", user.getEmail());
 
         // 소셜 로그인용 Authentication 객체 생성
         Authentication authentication = new UsernamePasswordAuthenticationToken(

--- a/src/main/java/org/synergym/backendapi/service/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/org/synergym/backendapi/service/oauth/CustomOAuth2UserService.java
@@ -1,7 +1,8 @@
 package org.synergym.backendapi.service.oauth;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
+import java.util.Map;
+import java.util.Optional;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -12,8 +13,8 @@ import org.synergym.backendapi.entity.Role;
 import org.synergym.backendapi.entity.User;
 import org.synergym.backendapi.repository.UserRepository;
 
-import java.util.Map;
-import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
@@ -31,18 +32,31 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         OAuth2UserInfo oAuth2UserInfo = getOAuth2UserInfo(registrationId, oAuth2User.getAttributes());
 
         String provider = oAuth2UserInfo.getProvider();
-        String providerId = oAuth2UserInfo.getProviderId();
         String email = oAuth2UserInfo.getEmail();
         String name = oAuth2UserInfo.getName();
 
-        // 우리 DB에 사용자가 있는지 확인
-        Optional<User> userOptional = userRepository.findByEmail(email);
+        // 탈퇴한 사용자 포함하여 이메일로 사용자 확인
+        Optional<User> userOptional = userRepository.findByEmailIncludingDeleted(email);
         User user;
 
         if (userOptional.isPresent()) {
-            // 이미 가입된 사용자인 경우
             user = userOptional.get();
-            log.info("기존 사용자로 로그인: {}", email);
+            
+            // 이미 활성화된 사용자인 경우
+            if (user.getUseYn() == 'Y') {
+                log.info("기존 사용자로 로그인: {}", email);
+            } else if (user.getUseYn() == 'N') {
+                // 탈퇴한 사용자가 소셜 로그인으로 재가입하는 경우
+                log.info("탈퇴한 사용자가 소셜 로그인으로 재가입합니다: {}", email);
+                
+                user.reactivate(); // useYn을 Y로 변경
+                user.updateName(name);
+                user.updateProvider(provider);
+                user.updatePassword(passwordEncoder.encode("SocialLoginPassword"));
+                
+                userRepository.save(user);
+                log.info("소셜 로그인 재가입 완료: {}", email);
+            }
         } else {
             // 처음 소셜 로그인하는 사용자인 경우, 자동 회원가입
             user = User.builder()
@@ -50,7 +64,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                     .name(name)
                     .password(passwordEncoder.encode("SocialLoginPassword")) // 소셜 로그인 사용자는 비밀번호를 직접 사용하지 않음
                     .role(Role.MEMBER)
-                    // provider, providerId 필드를 User 엔티티에 추가하는 것을 권장
+                    .provider(provider)
                     .build();
             userRepository.save(user);
             log.info("새로운 소셜 사용자로 회원가입: {}", email);


### PR DESCRIPTION
- BaseEntity에 reactivate() 메서드 추가하여 useYn을 Y로 변경
- UserRepository에 탈퇴 사용자 포함 검색 메서드 추가
- AuthServiceImpl에 일반 회원가입 시 재가입 로직 구현
- CustomOAuth2UserService에 소셜 로그인 재가입 로직 구현
- 탈퇴한 사용자가 동일 이메일로 재가입 시 기존 데이터 재활성화