### PR TITLE
feat(chatbot): enhance session management and message lifecycle in Redis

### DIFF
--- a/src/main/java/org/synergym/backendapi/service/ChatbotRedisService.java
+++ b/src/main/java/org/synergym/backendapi/service/ChatbotRedisService.java
@@ -107,7 +107,7 @@ public class ChatbotRedisService {
     // 사용자별 활성 세션 저장
     public void setActiveSession(Integer userId, String sessionId) {
         String key = "chat:active:" + userId;
-        redisTemplate.opsForValue().set(key, sessionId, Duration.ofHours(1));
+        redisTemplate.opsForValue().set(key, sessionId, Duration.ofHours(24));
     }
 
     // 사용자별 활성 세션 조회


### PR DESCRIPTION
- Extend Redis session TTL from 1 hour to 24 hours for longer chat persistence
- Prevent duplicate session creation by reusing active sessions per user
- Always return a greeting message for initial chatbot interactions
- Limit chat history to 50 messages per session for efficient storage
