### PR TITLE
feat(badge): 뱃지 시스템 백엔드 API 구현

### DIFF
--- a/src/main/java/org/synergym/backendapi/controller/UserController.java
+++ b/src/main/java/org/synergym/backendapi/controller/UserController.java
@@ -14,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.synergym.backendapi.dto.BadgeDTO;
 import org.synergym.backendapi.dto.UserDTO;
 import org.synergym.backendapi.dto.UserGoalDTO;
 import org.synergym.backendapi.dto.WeeklyMonthlyStats;
@@ -148,5 +149,16 @@ public class UserController {
         userService.saveUserGoals(userId, weeklyGoalString, monthlyGoalString);
 
         return ResponseEntity.ok().build();
+    }
+    
+    /**
+     * 특정 사용자가 획득한 모든 뱃지 목록 조회
+     * @param userId 사용자 ID
+     * @return 뱃지 DTO 리스트
+     */
+    @GetMapping("/{userId}/badges")
+    public ResponseEntity<List<BadgeDTO>> getUserBadges(@PathVariable int userId) {
+        List<BadgeDTO> badges = userService.getUserBadges(userId);
+        return ResponseEntity.ok(badges);
     }
 }

--- a/src/main/java/org/synergym/backendapi/dto/BadgeDTO.java
+++ b/src/main/java/org/synergym/backendapi/dto/BadgeDTO.java
@@ -1,0 +1,36 @@
+package org.synergym.backendapi.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.synergym.backendapi.entity.Badge;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class BadgeDTO {
+
+    private final Integer id;
+    private final String name;
+    private final String description;
+    private final String imageUrl;
+    private final LocalDateTime createdAt;
+
+    @Builder
+    public BadgeDTO(Integer id, String name, String description, String imageUrl, LocalDateTime createdAt) {
+        this.id = id;
+        this.name = name;
+        this.description = description;
+        this.imageUrl = imageUrl;
+        this.createdAt = createdAt;
+    }
+
+    // Badge 엔티티를 BadgeDTO로 변환하는 정적 팩토리 메서드
+    public static BadgeDTO fromEntity(Badge badge) {
+        return BadgeDTO.builder()
+                .id(badge.getId())
+                .name(badge.getName())
+                .description(badge.getDescription())
+                .createdAt(badge.getCreatedAt()) // BaseEntity의 createdAt 사용
+                .build();
+    }
+}

--- a/src/main/java/org/synergym/backendapi/repository/UserBadgeRepository.java
+++ b/src/main/java/org/synergym/backendapi/repository/UserBadgeRepository.java
@@ -3,6 +3,10 @@ package org.synergym.backendapi.repository;
 
 import org.synergym.backendapi.entity.UserBadge;
 import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
 public interface UserBadgeRepository extends JpaRepository<UserBadge, Integer> {
+
+    // 특정 사용자 ID로 그 사용자가 획득한 모든 UserBadge 정보를 조회
+    List<UserBadge> findByUserId(int userId);
 }

--- a/src/main/java/org/synergym/backendapi/service/UserService.java
+++ b/src/main/java/org/synergym/backendapi/service/UserService.java
@@ -2,6 +2,7 @@ package org.synergym.backendapi.service;
 
 
 import org.springframework.web.multipart.MultipartFile;
+import org.synergym.backendapi.dto.BadgeDTO;
 import org.synergym.backendapi.dto.UserDTO;
 import org.synergym.backendapi.entity.User;
 
@@ -64,6 +65,14 @@ public interface UserService {
 
 
     void saveUserGoals(Integer userId, String weeklyGoal, String monthlyGoal);
+
+
+    /**
+     * 특정 사용자가 획득한 모든 뱃지 목록 조회
+     * @param userId 사용자 ID
+     * @return 뱃지 DTO 리스트
+     */
+    List<BadgeDTO> getUserBadges(int userId);
 
 
     default UserDTO entityToDTO(User user){


### PR DESCRIPTION
사용자 동기부여를 위한 뱃지(업적) 시스템의 백엔드 기능을 구현합니다.

1.  **뱃지 도메인 및 엔티티 추가**
    -   `Badge` (뱃지 정보), `UserBadge` (사용자와 뱃지 연결) 엔티티를 신규 설계하고 추가했습니다.
    -   `Badge` 엔티티에는 프론트엔드 요구사항에 맞춰 `imageUrl` 필드를 추가했습니다.

2.  **뱃지 수여 API 구현**
    -   `POST /api/achievements/{user_id}`
    -   AI 코치 등이 사용자에게 뱃지를 부여할 수 있는 API를 구현했습니다.
    -   `AchievementController`, `AchievementService`를 신규 생성하여 뱃지 수여 로직을 처리합니다.

3.  **사용자 뱃지 목록 조회 API 구현**
    -   `GET /api/users/{userId}/badges`
    -   프론트엔드 마이페이지에서 사용자가 획득한 뱃지 목록을 조회할 수 있는 API를 구현했습니다.
    -   `UserController`와 `UserService`에 관련 로직을 추가하고, `UserBadgeRepository`를 통해 데이터를 조회합니다.
    -   `BadgeDTO`를 도입하여 클라이언트에 최적화된 데이터를 반환합니다.