### PR TITLE
feat: Implement posture analysis endpoint and data persistence

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 	implementation 'com.cloudinary:cloudinary-http44:1.37.0'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 tasks.named('test') {

--- a/src/main/java/org/synergym/backendapi/controller/AnalysisHistoryController.java
+++ b/src/main/java/org/synergym/backendapi/controller/AnalysisHistoryController.java
@@ -5,9 +5,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.synergym.backendapi.dto.AnalysisHistoryDTO;
+import org.synergym.backendapi.dto.AnalysisRequestDTO;
 import org.synergym.backendapi.service.AnalysisHistoryService;
+import org.synergym.backendapi.service.PostureGraphClient;
 
 import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/analysis-histories")
@@ -15,14 +18,44 @@ import java.util.List;
 public class AnalysisHistoryController {
 
     private final AnalysisHistoryService analysisHistoryService;
+    private final PostureGraphClient postureGraphClient;
 
-    // 특정 사용자의 분석 기록 생성
+    // Cloudinary URL을 받아 분석 요청
     @PostMapping("/user/{userId}")
     public ResponseEntity<AnalysisHistoryDTO> createAnalysisHistory(
             @PathVariable int userId,
-            @RequestBody AnalysisHistoryDTO requestDTO) {
-        AnalysisHistoryDTO createdHistory = analysisHistoryService.createAnalysisHistory(requestDTO, userId);
-        return new ResponseEntity<>(createdHistory, HttpStatus.CREATED);
+            @RequestBody AnalysisRequestDTO requestDTO) {
+
+        // 1. Python 서버에 분석 요청 (Cloudinary URL 사용)
+        Map<String, Object> result = postureGraphClient.analyzeWithGraph(requestDTO.getImageUrl(), requestDTO.getMode());
+
+        // 2. 결과 DTO 생성
+        AnalysisHistoryDTO dto = new AnalysisHistoryDTO();
+        dto.setUserId(userId);
+        dto.setFrontImageUrl(requestDTO.getImageUrl());
+        dto.setDiagnosis((String) result.get("diagnosis"));
+        dto.setRadarChartUrl((String) result.get("radar_chart_url"));
+        
+        // 점수 등 추가 필드도 result에서 추출해 dto에 set (예시)
+        if (result.get("spineCurvScore") != null) dto.setSpineCurvScore((Integer) result.get("spineCurvScore"));
+        if (result.get("spineScolScore") != null) dto.setSpineScolScore((Integer) result.get("spineScolScore"));
+        if (result.get("pelvicScore") != null) dto.setPelvicScore((Integer) result.get("pelvicScore"));
+        if (result.get("neckScore") != null) dto.setNeckScore((Integer) result.get("neckScore"));
+        if (result.get("shoulderScore") != null) dto.setShoulderScore((Integer) result.get("shoulderScore"));
+        Object feedbackObj = result.get("feedback");
+        if (feedbackObj instanceof Map) {
+            dto.setFeedback((Map<String, Object>) feedbackObj);
+        }
+        Object measurementsObj = result.get("measurements");
+        if (measurementsObj instanceof Map) {
+            dto.setMeasurements((Map<String, Object>) measurementsObj);
+        }
+
+        // 3. DB 저장
+        AnalysisHistoryDTO saved = analysisHistoryService.createAnalysisHistory(dto, userId);
+
+        // 4. 저장된 DTO 반환 (id 포함)
+        return new ResponseEntity<>(saved, HttpStatus.CREATED);
     }
 
     // Id로 특정 분석 기록 조회

--- a/src/main/java/org/synergym/backendapi/controller/CloudinaryController.java
+++ b/src/main/java/org/synergym/backendapi/controller/CloudinaryController.java
@@ -22,9 +22,12 @@ public class CloudinaryController {
     @PostMapping("/upload")
     public ResponseEntity<String> upload(@RequestParam("file") MultipartFile file) {
         try {
+            System.out.println("CloudinaryController: 파일 업로드 요청, 파일명=" + file.getOriginalFilename());
             String url = cloudinaryService.uploadImage(file);
+            System.out.println("CloudinaryController: 업로드 성공, URL=" + url);
             return ResponseEntity.ok(url);
         } catch (Exception e) {
+            e.printStackTrace();
             return ResponseEntity.badRequest().body("업로드 실패: " + e.getMessage());
         }
     }

--- a/src/main/java/org/synergym/backendapi/dto/AnalysisHistoryDTO.java
+++ b/src/main/java/org/synergym/backendapi/dto/AnalysisHistoryDTO.java
@@ -6,6 +6,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 @Data
 @Builder
@@ -25,4 +26,12 @@ public class AnalysisHistoryDTO {
     private String frontImageUrl; // 정면 분석 이미지 url
     private String sideImageUrl; // 측면 분석 이미지 url
     private LocalDateTime createdAt; // 분석 생성 일시
+
+    // 분석 결과 및 레이더 차트 URL 추가
+    private String diagnosis; // AI 진단 결과
+    private String radarChartUrl; // 레이더 차트 이미지 URL
+
+    // 부위별 피드백 및 측정값 추가
+    private Map<String, Object> feedback;
+    private Map<String, Object> measurements;
 }

--- a/src/main/java/org/synergym/backendapi/dto/AnalysisRequestDTO.java
+++ b/src/main/java/org/synergym/backendapi/dto/AnalysisRequestDTO.java
@@ -1,0 +1,9 @@
+package org.synergym.backendapi.dto;
+
+import lombok.Data;
+ 
+@Data
+public class AnalysisRequestDTO {
+    private String imageUrl; // Cloudinary 이미지 URL
+    private String mode;     // 분석 모드 (예: "front")
+} 

--- a/src/main/java/org/synergym/backendapi/entity/AnalysisHistory.java
+++ b/src/main/java/org/synergym/backendapi/entity/AnalysisHistory.java
@@ -44,8 +44,20 @@ public class AnalysisHistory extends BaseEntity {
     @Column(name = "side_image_url", length = 255)
     private String sideImageUrl;
 
+    @Column(name = "diagnosis", length = 1000)
+    private String diagnosis;
+
+    @Column(name = "radar_chart_url", length = 255)
+    private String radarChartUrl;
+
+    @Column(name = "feedback", columnDefinition = "TEXT")
+    private String feedback; // JSON 문자열로 저장
+
+    @Column(name = "measurements", columnDefinition = "TEXT")
+    private String measurements; // JSON 문자열로 저장
+
     @Builder
-    public AnalysisHistory(User user, int spineCurvScore, int spineScolScore, int pelvicScore, int neckScore, int shoulderScore, String frontImageUrl, String sideImageUrl) {
+    public AnalysisHistory(User user, int spineCurvScore, int spineScolScore, int pelvicScore, int neckScore, int shoulderScore, String frontImageUrl, String sideImageUrl, String diagnosis, String radarChartUrl, String feedback, String measurements) {
         this.user = user;
         this.spineCurvScore = spineCurvScore;
         this.spineScolScore = spineScolScore;
@@ -54,6 +66,10 @@ public class AnalysisHistory extends BaseEntity {
         this.shoulderScore = shoulderScore;
         this.frontImageUrl = frontImageUrl;
         this.sideImageUrl = sideImageUrl;
+        this.diagnosis = diagnosis;
+        this.radarChartUrl = radarChartUrl;
+        this.feedback = feedback;
+        this.measurements = measurements;
     }
 
     public void updateSpineCurvScore(int newSpineCurvScore) {
@@ -82,5 +98,34 @@ public class AnalysisHistory extends BaseEntity {
 
     public void updateSideImageUrl(String newSideImageUrl) {
         this.sideImageUrl = newSideImageUrl;
+    }
+
+    public String getDiagnosis() {
+        return diagnosis;
+    }
+
+    public String getRadarChartUrl() {
+        return radarChartUrl;
+    }
+
+    public void updateDiagnosis(String newDiagnosis) {
+        this.diagnosis = newDiagnosis;
+    }
+
+    public void updateRadarChartUrl(String newRadarChartUrl) {
+        this.radarChartUrl = newRadarChartUrl;
+    }
+
+    public void updateFeedback(String newFeedback) {
+        this.feedback = newFeedback;
+    }
+    public void updateMeasurements(String newMeasurements) {
+        this.measurements = newMeasurements;
+    }
+    public String getFeedback() {
+        return feedback;
+    }
+    public String getMeasurements() {
+        return measurements;
     }
 }

--- a/src/main/java/org/synergym/backendapi/service/AnalysisHistoryService.java
+++ b/src/main/java/org/synergym/backendapi/service/AnalysisHistoryService.java
@@ -5,6 +5,7 @@ import org.synergym.backendapi.entity.AnalysisHistory;
 import org.synergym.backendapi.entity.User;
 
 import java.util.List;
+import java.util.Map;
 
 public interface AnalysisHistoryService {
 
@@ -46,6 +47,18 @@ public interface AnalysisHistoryService {
     void deleteAnalysisHistory(int id);
 
     default AnalysisHistory DTOtoEntity(AnalysisHistoryDTO dto, User user) {
+        String feedbackJson = null;
+        String measurementsJson = null;
+        try {
+            if (dto.getFeedback() != null) {
+                feedbackJson = com.fasterxml.jackson.databind.json.JsonMapper.builder().build().writeValueAsString(dto.getFeedback());
+            }
+            if (dto.getMeasurements() != null) {
+                measurementsJson = com.fasterxml.jackson.databind.json.JsonMapper.builder().build().writeValueAsString(dto.getMeasurements());
+            }
+        } catch (Exception e) {
+            // 변환 실패 시 null 유지
+        }
         return AnalysisHistory.builder()
                 .user(user)
                 .spineCurvScore(dto.getSpineCurvScore())
@@ -55,10 +68,26 @@ public interface AnalysisHistoryService {
                 .shoulderScore(dto.getShoulderScore())
                 .frontImageUrl(dto.getFrontImageUrl())
                 .sideImageUrl(dto.getSideImageUrl())
+                .diagnosis(dto.getDiagnosis())
+                .radarChartUrl(dto.getRadarChartUrl())
+                .feedback(feedbackJson)
+                .measurements(measurementsJson)
                 .build();
     }
 
     default AnalysisHistoryDTO entityToDTO(AnalysisHistory history) {
+        Map<String, Object> feedbackMap = null;
+        Map<String, Object> measurementsMap = null;
+        try {
+            if (history.getFeedback() != null) {
+                feedbackMap = com.fasterxml.jackson.databind.json.JsonMapper.builder().build().readValue(history.getFeedback(), Map.class);
+            }
+            if (history.getMeasurements() != null) {
+                measurementsMap = com.fasterxml.jackson.databind.json.JsonMapper.builder().build().readValue(history.getMeasurements(), Map.class);
+            }
+        } catch (Exception e) {
+            // 변환 실패 시 null 유지
+        }
         return AnalysisHistoryDTO.builder()
                 .id(history.getId())
                 .userId(history.getUser().getId())
@@ -70,6 +99,10 @@ public interface AnalysisHistoryService {
                 .frontImageUrl(history.getFrontImageUrl())
                 .sideImageUrl(history.getSideImageUrl())
                 .createdAt(history.getCreatedAt())
+                .diagnosis(history.getDiagnosis())
+                .radarChartUrl(history.getRadarChartUrl())
+                .feedback(feedbackMap)
+                .measurements(measurementsMap)
                 .build();
     }
 }

--- a/src/main/java/org/synergym/backendapi/service/CloudinaryService.java
+++ b/src/main/java/org/synergym/backendapi/service/CloudinaryService.java
@@ -20,7 +20,9 @@ public class CloudinaryService {
 
     //이미지 파일을 Cloudinary에 업로드
     public String uploadImage(MultipartFile file) throws IOException {
+        System.out.println("CloudinaryService: 업로드 시작");
         Map uploadResult = cloudinary.uploader().upload(file.getBytes(), ObjectUtils.emptyMap());
+        System.out.println("CloudinaryService: 업로드 성공, URL=" + uploadResult.get("secure_url"));
         return uploadResult.get("secure_url").toString(); // 업로드된 이미지의 HTTPS 주소
     }
     

--- a/src/main/java/org/synergym/backendapi/service/PostureGraphClient.java
+++ b/src/main/java/org/synergym/backendapi/service/PostureGraphClient.java
@@ -1,0 +1,43 @@
+package org.synergym.backendapi.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.http.MediaType;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@Service
+public class PostureGraphClient {
+    private final WebClient webClient = WebClient.create("http://localhost:8000"); // Python 서버 주소
+
+    public Map<String, Object> analyzeWithGraph(String imageUrl, String mode) {
+        Map<String, String> request = new HashMap<>();
+        request.put("image_url", imageUrl);
+        request.put("analysis_mode", mode);
+
+        log.info("Sending request to Python server - Image URL: {}, Mode: {}", imageUrl, mode);
+
+        try {
+            Map<String, Object> result = webClient.post()
+                    .uri("/analyze-graph")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                    .block();
+
+            log.info("Received response from Python server: {}", result);
+            return result;
+        } catch (WebClientResponseException e) {
+            log.error("Error communicating with Python server: Status {}, Message: {}, Code: {}", e.getStatusCode(), e.getMessage());
+            throw new RuntimeException("Python 서버와의 통신 중 오류가 발생했습니다: " + e.getMessage());
+        } catch (Exception e) {
+            log.error("Unexpected error in PostureGraphClient: {}", e.getMessage());
+            throw new RuntimeException("자세 분석 중 예상치 못한 오류가 발생했습니다: " + e.getMessage());
+        }
+    }
+} 


### PR DESCRIPTION
자세 분석 요청을 처리하고 AI 서버와 연동

- API 엔드포인트
  - `AnalysisHistoryController`에 Cloudinary 이미지 URL을 받아 AI 분석을 요청
  -  반환된 결과를 DB에 저장
  - 생성된 분석 ID를 클라이언트에 반환하는 엔드포인트 구현
 
- 데이터 모델 확장
  - `AnalysisHistory` Entity와 `AnalysisHistoryDTO`에 `feedback`(텍스트 진단), `measurements`(측정된 각도 값) 필드 추가

- 외부 API 연동
  - PostureGraphClient`를 통해 FastAPI 서버와 안정적으로 통신하며, 로깅 및 예외 처리를 강화

- 타입 안정성
  - Python 서비스로부터 받은 응답을 처리할 때, `instanceof`를 사용하여 안전하게 타입을 확인하고 캐스팅
 
- 아키텍처
  - 각 분석 요청마다 새로운 분석 이력을 생성하여 DB에 누적 저장함으로써, 사용자의 자세 변화 추이를 관리