### PR TITLE
refactor: Unify FastAPI request structure and fix diagnosis type issue

### DIFF
--- a/src/main/java/org/synergym/backendapi/controller/AnalysisHistoryController.java
+++ b/src/main/java/org/synergym/backendapi/controller/AnalysisHistoryController.java
@@ -63,14 +63,121 @@ public class AnalysisHistoryController {
         if (feedbackObj instanceof Map) {
             dto.setFeedback((Map<String, Object>) feedbackObj);
         }
-        Object measurementsObj = result.get("measurements");
-        if (measurementsObj instanceof Map) {
-            dto.setMeasurements((Map<String, Object>) measurementsObj);
+        // --- measurements 항상 DTO에 넣기 ---
+        Object poseDataObj = result.get("pose_data");
+        if (poseDataObj instanceof Map) {
+            Map<String, Object> poseMap = (Map<String, Object>) poseDataObj;
+            Object measurementsObj = poseMap.get("measurements");
+            System.out.println("[단일] measurements: " + measurementsObj);
+            System.out.println("[단일] measurements type: " + (measurementsObj != null ? measurementsObj.getClass() : "null"));
+            if (measurementsObj instanceof Map) {
+                dto.setMeasurements((Map<String, Object>) measurementsObj);
+            }
         }
-
         // 3. DB 저장
         AnalysisHistoryDTO saved = analysisHistoryService.createAnalysisHistory(dto, userId);
 
+        // 4. 저장된 DTO 반환 (id 포함)
+        return new ResponseEntity<>(saved, HttpStatus.CREATED);
+    }
+
+    // 정면/측면 이미지를 한 번에 받아 merge 분석 요청
+    @PostMapping("/merge/user/{userId}")
+    public ResponseEntity<AnalysisHistoryDTO> createMergedAnalysisHistory(
+            @PathVariable int userId,
+            @RequestBody Map<String, String> requestBody) {
+
+        String frontImageUrl = requestBody.get("front_image_url");
+        String sideImageUrl = requestBody.get("side_image_url");
+
+        // 1. Python 서버에 merge 분석 요청
+        Map<String, Object> result = postureGraphClient.analyzeWithGraphMerge(frontImageUrl, sideImageUrl);
+
+        // 2. 결과 DTO 생성 및 저장 (기존 createAnalysisHistory와 유사하게)
+        AnalysisHistoryDTO dto = new AnalysisHistoryDTO();
+        dto.setUserId(userId);
+        dto.setFrontImageUrl(frontImageUrl);
+        dto.setSideImageUrl(sideImageUrl);
+        // Handle diagnosis field - convert Map to JSON string if needed
+        Object diagnosisObj = result.get("diagnosis");
+        if (diagnosisObj instanceof Map) {
+            try {
+                String diagnosisJson = com.fasterxml.jackson.databind.json.JsonMapper.builder().build().writeValueAsString(diagnosisObj);
+                dto.setDiagnosis(diagnosisJson);
+            } catch (Exception e) {
+                dto.setDiagnosis("진단 정보 변환 실패");
+            }
+        } else if (diagnosisObj instanceof String) {
+            dto.setDiagnosis((String) diagnosisObj);
+        } else if (diagnosisObj == null) {
+            dto.setDiagnosis("진단 정보가 없습니다.");
+        } else {
+            dto.setDiagnosis(diagnosisObj.toString());
+        }
+        dto.setRadarChartUrl((String) result.get("radar_chart_url"));
+        // 점수 등 추가 필드도 result에서 추출해 dto에 set (예시)
+        if (result.get("spineCurvScore") != null) dto.setSpineCurvScore((Integer) result.get("spineCurvScore"));
+        if (result.get("spineScolScore") != null) dto.setSpineScolScore((Integer) result.get("spineScolScore"));
+        if (result.get("pelvicScore") != null) dto.setPelvicScore((Integer) result.get("pelvicScore"));
+        if (result.get("neckScore") != null) dto.setNeckScore((Integer) result.get("neckScore"));
+        if (result.get("shoulderScore") != null) dto.setShoulderScore((Integer) result.get("shoulderScore"));
+        Object feedbackObj = result.get("feedback");
+        if (feedbackObj instanceof Map) {
+            dto.setFeedback((Map<String, Object>) feedbackObj);
+        }
+        // --- merge measurements 합치기 ---
+        Object frontPoseObj = result.get("front_pose_data");
+        Object sidePoseObj = result.get("side_pose_data");
+        Map<String, Object> mergedMeasurements = new java.util.HashMap<>();
+        if (frontPoseObj instanceof Map) {
+            Map<String, Object> frontMap = (Map<String, Object>) frontPoseObj;
+            Object frontMeasurementsObj = frontMap.get("measurements");
+            System.out.println("[merge] front measurements: " + frontMeasurementsObj);
+            System.out.println("[merge] front measurements type: " + (frontMeasurementsObj != null ? frontMeasurementsObj.getClass() : "null"));
+            Map<String, Object> frontMeasurementsMap = null;
+            if (frontMeasurementsObj instanceof Map) {
+                frontMeasurementsMap = (Map<String, Object>) frontMeasurementsObj;
+            } else if (frontMeasurementsObj instanceof String) {
+                try {
+                    frontMeasurementsMap = com.fasterxml.jackson.databind.json.JsonMapper.builder().build().readValue((String) frontMeasurementsObj, Map.class);
+                } catch (Exception e) {
+                    // 변환 실패 시 무시
+                }
+            }
+            if (frontMeasurementsMap != null) {
+                for (Map.Entry<String, Object> entry : frontMeasurementsMap.entrySet()) {
+                    mergedMeasurements.put(entry.getKey(), entry.getValue());
+                }
+            }
+        }
+        if (sidePoseObj instanceof Map) {
+            Map<String, Object> sideMap = (Map<String, Object>) sidePoseObj;
+            Object sideMeasurementsObj = sideMap.get("measurements");
+            System.out.println("[merge] side measurements: " + sideMeasurementsObj);
+            System.out.println("[merge] side measurements type: " + (sideMeasurementsObj != null ? sideMeasurementsObj.getClass() : "null"));
+            Map<String, Object> sideMeasurementsMap = null;
+            if (sideMeasurementsObj instanceof Map) {
+                sideMeasurementsMap = (Map<String, Object>) sideMeasurementsObj;
+            } else if (sideMeasurementsObj instanceof String) {
+                try {
+                    sideMeasurementsMap = com.fasterxml.jackson.databind.json.JsonMapper.builder().build().readValue((String) sideMeasurementsObj, Map.class);
+                } catch (Exception e) {
+                    // 변환 실패 시 무시
+                }
+            }
+            if (sideMeasurementsMap != null) {
+                for (Map.Entry<String, Object> entry : sideMeasurementsMap.entrySet()) {
+                    if (entry.getValue() != null) {
+                        mergedMeasurements.put(entry.getKey(), entry.getValue());
+                    }
+                }
+            }
+        }
+        if (!mergedMeasurements.isEmpty()) {
+            dto.setMeasurements(mergedMeasurements);
+        }
+        // 3. DB 저장
+        AnalysisHistoryDTO saved = analysisHistoryService.createAnalysisHistory(dto, userId);
         // 4. 저장된 DTO 반환 (id 포함)
         return new ResponseEntity<>(saved, HttpStatus.CREATED);
     }

--- a/src/main/java/org/synergym/backendapi/service/AiChatbotService.java
+++ b/src/main/java/org/synergym/backendapi/service/AiChatbotService.java
@@ -1,9 +1,9 @@
 package org.synergym.backendapi.service;
 
-import org.synergym.backendapi.dto.ChatRequestDTO;
 import org.synergym.backendapi.dto.ChatResponseDTO;
+import java.util.Map;
 
 public interface AiChatbotService {
-    ChatResponseDTO callFastApi(ChatRequestDTO requestDTO);
-    ChatResponseDTO callFastApiCommentSummary(ChatRequestDTO requestDTO);
+    ChatResponseDTO callFastApiAiCoach(Map<String, Object> fastApiRequest);
+    ChatResponseDTO callFastApiYoutube(Map<String, Object> fastApiRequest, String type);
 } 

--- a/src/main/java/org/synergym/backendapi/service/AiChatbotServiceImpl.java
+++ b/src/main/java/org/synergym/backendapi/service/AiChatbotServiceImpl.java
@@ -2,28 +2,29 @@ package org.synergym.backendapi.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.synergym.backendapi.dto.ChatRequestDTO;
 import org.synergym.backendapi.dto.ChatResponseDTO;
+import java.util.Map;
 
 @Service
 public class AiChatbotServiceImpl implements AiChatbotService {
     private final WebClient webClient = WebClient.create("http://localhost:8000"); // FastAPI 주소
 
     @Override
-    public ChatResponseDTO callFastApi(ChatRequestDTO requestDTO) {
+    public ChatResponseDTO callFastApiAiCoach(Map<String, Object> fastApiRequest) {
         return webClient.post()
-                .uri("/chatbot")
-                .bodyValue(requestDTO)
+                .uri("/ai-coach")
+                .bodyValue(fastApiRequest)
                 .retrieve()
                 .bodyToMono(ChatResponseDTO.class)
                 .block();
     }
 
     @Override
-    public ChatResponseDTO callFastApiCommentSummary(ChatRequestDTO requestDTO) {
+    public ChatResponseDTO callFastApiYoutube(Map<String, Object> fastApiRequest, String type) {
+        fastApiRequest.put("type", type);
         return webClient.post()
-                .uri("/chatbot/comment-summary")
-                .bodyValue(requestDTO)
+                .uri("/youtube")
+                .bodyValue(fastApiRequest)
                 .retrieve()
                 .bodyToMono(ChatResponseDTO.class)
                 .block();

--- a/src/main/java/org/synergym/backendapi/service/PostureGraphClient.java
+++ b/src/main/java/org/synergym/backendapi/service/PostureGraphClient.java
@@ -40,4 +40,31 @@ public class PostureGraphClient {
             throw new RuntimeException("자세 분석 중 예상치 못한 오류가 발생했습니다: " + e.getMessage());
         }
     }
+
+    public Map<String, Object> analyzeWithGraphMerge(String frontImageUrl, String sideImageUrl) {
+        Map<String, String> request = new HashMap<>();
+        request.put("front_image_url", frontImageUrl);
+        request.put("side_image_url", sideImageUrl);
+
+        log.info("Sending merge request to Python server - Front: {}, Side: {}", frontImageUrl, sideImageUrl);
+
+        try {
+            Map<String, Object> result = webClient.post()
+                    .uri("/analyze-graph/merge")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .bodyValue(request)
+                    .retrieve()
+                    .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
+                    .block();
+
+            log.info("Received merge response from Python server: {}", result);
+            return result;
+        } catch (WebClientResponseException e) {
+            log.error("Error communicating with Python server (merge): Status {}, Message: {}, Code: {}", e.getStatusCode(), e.getMessage());
+            throw new RuntimeException("Python 서버와의 통신 중 오류(merge): " + e.getMessage());
+        } catch (Exception e) {
+            log.error("Unexpected error in PostureGraphClient (merge): {}", e.getMessage());
+            throw new RuntimeException("자세 분석(merge) 중 예상치 못한 오류: " + e.getMessage());
+        }
+    }
 } 


### PR DESCRIPTION
- diagnosis를 JSON 문자열에서 Map으로 변환하여 FastAPI에 전달 (422 에러 해결)
- recommended_exercise도 Map으로 전달되도록 구조 점검
- /chatbot/send에서 type 값에 따라 FastAPI 라우터 분기 로직 명확화
- 분석/챗봇 요청 시 필요한 모든 정보(진단, 추천운동 등) FastAPI에 직접 전달