### PR TITLE
feat: connect emotion-log data

### DIFF
--- a/src/main/java/org/synergym/backendapi/dto/EmotionAnalysisRequest.java
+++ b/src/main/java/org/synergym/backendapi/dto/EmotionAnalysisRequest.java
@@ -1,0 +1,8 @@
+package org.synergym.backendapi.dto;
+
+/**
+ * FastAPI 감성 분석 서비스에 요청을 보낼 때 사용할 DTO입니다.
+ * @param memo 분석할 텍스트 메모
+ */
+public record EmotionAnalysisRequest(String memo) {
+}

--- a/src/main/java/org/synergym/backendapi/repository/ExerciseLogRepository.java
+++ b/src/main/java/org/synergym/backendapi/repository/ExerciseLogRepository.java
@@ -28,5 +28,5 @@ public interface ExerciseLogRepository extends JpaRepository<ExerciseLog, Intege
     List<Map<String, Object>> countLogsGroupByUser(@Param("startDate") LocalDate startDate, @Param("endDate") LocalDate endDate);
 
     // 사용자와 날짜로 운동 기록 조회
-    Optional<ExerciseLog> findByUserAndExerciseDate(User user, LocalDate date);
+    List<ExerciseLog> findByUserAndExerciseDate(User user, LocalDate exerciseDate);
 }

--- a/src/main/java/org/synergym/backendapi/service/GoalGraphClient.java
+++ b/src/main/java/org/synergym/backendapi/service/GoalGraphClient.java
@@ -42,13 +42,28 @@ public class GoalGraphClient {
 
             log.info("AI 목표 추천 서버로부터 응답을 성공적으로 변환했습니다: {}", response);
 
-            if (response.getGeneratedBadge() != null) {
-                achievementService.awardBadgeToUser(
-                        response.getUserId(),
-                        response.getGeneratedBadge().getName(),
-                        response.getGeneratedBadge().getDescription()
-                );
-            }
+if (response.getGeneratedBadge() != null) {
+    String badgeName = response.getGeneratedBadge().getName();
+    String badgeDescription = response.getGeneratedBadge().getDescription();
+    
+    // null 체크 추가
+    if (badgeName == null || badgeName.trim().isEmpty()) {
+        log.warn("생성된 뱃지의 이름이 null이거나 비어있습니다. 뱃지 생성을 건너뜁니다.");
+        return response;
+    }
+    
+    try {
+        achievementService.awardBadgeToUser(
+            response.getUserId(),
+            badgeName,
+            badgeDescription
+        );
+    } catch (Exception e) {
+        log.error("뱃지 생성 중 오류 발생: {}", e.getMessage());
+        // 뱃지 생성 실패를 로그로 남기고 계속 진행
+        // 전체 응답은 반환
+    }
+}
 
             return response;
 


### PR DESCRIPTION
- FastAPI 감성 분석 서비스에 요청을 보낼 때 사용할 DTO 추가 (파라미터: 분석할 텍스트 메모)
- 메모가 비어있고 운동기록만 저장하는 경우 처리 로직 추가
- 리포지토리 리턴타입 수정