### PR TITLE
feat: use exercise IDs and add routine suggestions based on analysishistory

### DIFF
--- a/src/main/java/org/synergym/backendapi/controller/AnalysisHistoryController.java
+++ b/src/main/java/org/synergym/backendapi/controller/AnalysisHistoryController.java
@@ -74,6 +74,12 @@ public class AnalysisHistoryController {
                 dto.setMeasurements((Map<String, Object>) measurementsObj);
             }
         }
+
+        Object recommendedExerciseObj = result.get("recommended_exercise");
+        if (recommendedExerciseObj instanceof Map) {
+            dto.setRecommendedExercise((Map<String, Object>) recommendedExerciseObj);
+        }
+
         // 3. DB 저장
         AnalysisHistoryDTO saved = analysisHistoryService.createAnalysisHistory(dto, userId);
 
@@ -176,6 +182,12 @@ public class AnalysisHistoryController {
         if (!mergedMeasurements.isEmpty()) {
             dto.setMeasurements(mergedMeasurements);
         }
+
+        Object recommendedExerciseObj = result.get("recommended_exercise");
+        if (recommendedExerciseObj instanceof Map) {
+            dto.setRecommendedExercise((Map<String, Object>) recommendedExerciseObj);
+        }
+        
         // 3. DB 저장
         AnalysisHistoryDTO saved = analysisHistoryService.createAnalysisHistory(dto, userId);
         // 4. 저장된 DTO 반환 (id 포함)

--- a/src/main/java/org/synergym/backendapi/controller/ChatbotController.java
+++ b/src/main/java/org/synergym/backendapi/controller/ChatbotController.java
@@ -185,9 +185,6 @@ public class ChatbotController {
 
     // 추천운동 추출 예시 (실제 로직에 맞게 구현)
     private Map<String, Object> getRecommendedExerciseFromAnalysis(AnalysisHistoryDTO analysis) {
-        Map<String, Object> exercise = new java.util.HashMap<>();
-        exercise.put("name", "목 스트레칭");
-        // ... 추가 필드 필요시 구현
-        return exercise;
+        return analysis.getRecommendedExercise();
     }
 }

--- a/src/main/java/org/synergym/backendapi/controller/ExerciseController.java
+++ b/src/main/java/org/synergym/backendapi/controller/ExerciseController.java
@@ -90,6 +90,16 @@ public class ExerciseController {
         return ResponseEntity.ok(exerciseDto);
     }
 
+    // 운동 이름과 정확히 일치 검색
+    @GetMapping("/search/exact")
+    public ResponseEntity<ExerciseDTO> getExerciseByExactName(@RequestParam String name) {
+        ExerciseDTO exercise = exerciseService.getExerciseByExactName(name);
+        if (exercise == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(exercise);
+    }
+
     /**
      * 사용자의 종합적인 데이터를 받아 AI 기반으로 운동을 추천합니다.
      * @param payloadDTO 사용자의 프로필, 운동 기록, 체형 분석 데이터 등

--- a/src/main/java/org/synergym/backendapi/controller/RoutineController.java
+++ b/src/main/java/org/synergym/backendapi/controller/RoutineController.java
@@ -8,8 +8,11 @@ import org.springframework.web.bind.annotation.*;
 import org.synergym.backendapi.dto.RoutineDTO;
 import org.synergym.backendapi.dto.RoutineExerciseDTO;
 import org.synergym.backendapi.dto.UpdateOrderRequest;
+import org.synergym.backendapi.dto.CreateRoutineWithRecommendedExerciseRequest;
+import org.synergym.backendapi.dto.ExerciseDTO;
 import org.synergym.backendapi.service.RoutineExerciseService;
 import org.synergym.backendapi.service.RoutineService;
+import org.synergym.backendapi.service.ExerciseService;
 
 import java.util.List;
 
@@ -20,6 +23,7 @@ public class RoutineController {
 
     private final RoutineService routineService;
     private final RoutineExerciseService routineExerciseService;
+    private final ExerciseService exerciseService;
 
     // 특정 사용자의 투틴 생성
     @PostMapping("/user/{userId}")
@@ -28,6 +32,20 @@ public class RoutineController {
             @PathVariable int userId) {
         RoutineDTO createdRoutine = routineService.createRoutine(routineDTO, userId);
         return new ResponseEntity<>(createdRoutine, HttpStatus.CREATED);
+    }
+
+    // 추천운동명으로 신규 루틴 생성 + 운동 추가
+    @PostMapping("/user/{userId}/with-exercise")
+    public ResponseEntity<RoutineDTO> createRoutineWithRecommendedExercise(
+            @RequestBody CreateRoutineWithRecommendedExerciseRequest req,
+            @PathVariable int userId) {
+        ExerciseDTO exercise = exerciseService.getExerciseById(req.getExerciseId());
+        if (exercise == null) {
+            return ResponseEntity.badRequest().body(null);
+        }
+        RoutineDTO result = routineService.createRoutineWithExercise(
+            req.getRoutineDTO(), userId, exercise.getId(), req.getOrder());
+        return new ResponseEntity<>(result, HttpStatus.CREATED);
     }
 
     // 특정 사용자의 모든 루틴 조회

--- a/src/main/java/org/synergym/backendapi/dto/AnalysisHistoryDTO.java
+++ b/src/main/java/org/synergym/backendapi/dto/AnalysisHistoryDTO.java
@@ -34,4 +34,5 @@ public class AnalysisHistoryDTO {
     // 부위별 피드백 및 측정값 추가
     private Map<String, Object> feedback;
     private Map<String, Object> measurements;
+    private Map<String, Object> recommendedExercise;
 }

--- a/src/main/java/org/synergym/backendapi/dto/CreateRoutineWithRecommendedExerciseRequest.java
+++ b/src/main/java/org/synergym/backendapi/dto/CreateRoutineWithRecommendedExerciseRequest.java
@@ -1,0 +1,10 @@
+package org.synergym.backendapi.dto;
+
+import lombok.Data;
+
+@Data
+public class CreateRoutineWithRecommendedExerciseRequest {
+    private RoutineDTO routineDTO;
+    private int exerciseId; // 운동 id로 변경
+    private int order;
+} 

--- a/src/main/java/org/synergym/backendapi/entity/AnalysisHistory.java
+++ b/src/main/java/org/synergym/backendapi/entity/AnalysisHistory.java
@@ -56,8 +56,11 @@ public class AnalysisHistory extends BaseEntity {
     @Column(name = "measurements", columnDefinition = "TEXT")
     private String measurements; // JSON 문자열로 저장
 
+    @Column(name = "recommended_exercise", columnDefinition = "TEXT")
+    private String recommendedExercise;
+
     @Builder
-    public AnalysisHistory(User user, int spineCurvScore, int spineScolScore, int pelvicScore, int neckScore, int shoulderScore, String frontImageUrl, String sideImageUrl, String diagnosis, String radarChartUrl, String feedback, String measurements) {
+    public AnalysisHistory(User user, int spineCurvScore, int spineScolScore, int pelvicScore, int neckScore, int shoulderScore, String frontImageUrl, String sideImageUrl, String diagnosis, String radarChartUrl, String feedback, String measurements, String recommendedExercise) {
         this.user = user;
         this.spineCurvScore = spineCurvScore;
         this.spineScolScore = spineScolScore;
@@ -70,6 +73,7 @@ public class AnalysisHistory extends BaseEntity {
         this.radarChartUrl = radarChartUrl;
         this.feedback = feedback;
         this.measurements = measurements;
+        this.recommendedExercise = recommendedExercise;
     }
 
     public void updateSpineCurvScore(int newSpineCurvScore) {

--- a/src/main/java/org/synergym/backendapi/repository/ExerciseRepository.java
+++ b/src/main/java/org/synergym/backendapi/repository/ExerciseRepository.java
@@ -15,6 +15,9 @@ public interface ExerciseRepository extends JpaRepository<Exercise, Integer> {
     // 운동 카테고리별 조회
     List<Exercise> findByCategory(String category);
     
+    // 운동 이름과 정확히 일치
+    Exercise findByName(String name);
+    
     // 좋아요 수 기준 인기 운동 조회
     @Query("SELECT e FROM Exercise e " +
            "LEFT JOIN ExerciseLike el ON e.id = el.exercise.id " +

--- a/src/main/java/org/synergym/backendapi/service/AiCoachClient.java
+++ b/src/main/java/org/synergym/backendapi/service/AiCoachClient.java
@@ -10,6 +10,15 @@ public class AiCoachClient {
     private final WebClient webClient = WebClient.create("http://localhost:8000");
 
     public ChatResponseDTO sendAiCoachRequest(Map<String, Object> requestBody) {
+        // 1. 원본 JSON 응답을 String으로 받아서 출력
+        String rawJson = webClient.post()
+                .uri("/ai-coach")
+                .bodyValue(requestBody)
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+
+        // 2. 기존대로 DTO로 변환해서 반환
         return webClient.post()
                 .uri("/ai-coach")
                 .bodyValue(requestBody)

--- a/src/main/java/org/synergym/backendapi/service/AnalysisHistoryService.java
+++ b/src/main/java/org/synergym/backendapi/service/AnalysisHistoryService.java
@@ -49,12 +49,16 @@ public interface AnalysisHistoryService {
     default AnalysisHistory DTOtoEntity(AnalysisHistoryDTO dto, User user) {
         String feedbackJson = null;
         String measurementsJson = null;
+        String recommendedExerciseJson = null;
         try {
             if (dto.getFeedback() != null) {
                 feedbackJson = com.fasterxml.jackson.databind.json.JsonMapper.builder().build().writeValueAsString(dto.getFeedback());
             }
             if (dto.getMeasurements() != null) {
                 measurementsJson = com.fasterxml.jackson.databind.json.JsonMapper.builder().build().writeValueAsString(dto.getMeasurements());
+            }
+            if (dto.getRecommendedExercise() != null) {
+                recommendedExerciseJson = com.fasterxml.jackson.databind.json.JsonMapper.builder().build().writeValueAsString(dto.getRecommendedExercise());
             }
         } catch (Exception e) {
             // 변환 실패 시 null 유지
@@ -72,18 +76,23 @@ public interface AnalysisHistoryService {
                 .radarChartUrl(dto.getRadarChartUrl())
                 .feedback(feedbackJson)
                 .measurements(measurementsJson)
+                .recommendedExercise(recommendedExerciseJson)
                 .build();
     }
 
     default AnalysisHistoryDTO entityToDTO(AnalysisHistory history) {
         Map<String, Object> feedbackMap = null;
         Map<String, Object> measurementsMap = null;
+        Map<String, Object> recommendedExerciseMap = null;
         try {
             if (history.getFeedback() != null) {
                 feedbackMap = com.fasterxml.jackson.databind.json.JsonMapper.builder().build().readValue(history.getFeedback(), Map.class);
             }
             if (history.getMeasurements() != null) {
                 measurementsMap = com.fasterxml.jackson.databind.json.JsonMapper.builder().build().readValue(history.getMeasurements(), Map.class);
+            }
+            if (history.getRecommendedExercise() != null) {
+                recommendedExerciseMap = com.fasterxml.jackson.databind.json.JsonMapper.builder().build().readValue(history.getRecommendedExercise(), Map.class);
             }
         } catch (Exception e) {
             // 변환 실패 시 null 유지
@@ -103,6 +112,7 @@ public interface AnalysisHistoryService {
                 .radarChartUrl(history.getRadarChartUrl())
                 .feedback(feedbackMap)
                 .measurements(measurementsMap)
+                .recommendedExercise(recommendedExerciseMap)
                 .build();
     }
 }

--- a/src/main/java/org/synergym/backendapi/service/ExerciseService.java
+++ b/src/main/java/org/synergym/backendapi/service/ExerciseService.java
@@ -33,6 +33,9 @@ public interface ExerciseService {
 
     ExerciseDTO getExerciseByIdWithStats(Integer id);
 
+    // 운동 이름과 정확히 일치
+    ExerciseDTO getExerciseByExactName(String name);
+
     // DTO -> Entity 변환
     default Exercise DTOtoEntity(ExerciseDTO dto) {
         return Exercise.builder()

--- a/src/main/java/org/synergym/backendapi/service/ExerciseServiceImpl.java
+++ b/src/main/java/org/synergym/backendapi/service/ExerciseServiceImpl.java
@@ -123,4 +123,13 @@ public class ExerciseServiceImpl implements ExerciseService {
         
         return entityToDTOWithStats(exercise, likeCount, routineCount);
     }
+
+    @Override
+    public ExerciseDTO getExerciseByExactName(String name) {
+        Exercise exercise = exerciseRepository.findByName(name);
+        if (exercise == null) {
+            return null;
+        }
+        return entityToDTO(exercise);
+    }
 }

--- a/src/main/java/org/synergym/backendapi/service/RoutineService.java
+++ b/src/main/java/org/synergym/backendapi/service/RoutineService.java
@@ -14,6 +14,9 @@ public interface RoutineService {
     // 루틴 생성
     RoutineDTO createRoutine(RoutineDTO routineDTO, int userId);
 
+    // 챗봇: 신규 루틴 생성 + 운동 추가 (트랜잭션)
+    RoutineDTO createRoutineWithExercise(RoutineDTO routineDTO, int userId, int exerciseId, int order);
+
     // 루틴 상세 조회
     RoutineDTO getRoutineDetails(int routineId);
 

--- a/src/main/java/org/synergym/backendapi/service/RoutineServiceImpl.java
+++ b/src/main/java/org/synergym/backendapi/service/RoutineServiceImpl.java
@@ -28,6 +28,7 @@ public class RoutineServiceImpl implements RoutineService {
     private final UserRepository userRepository;
     private final RoutineExerciseRepository routineExerciseRepository;
     private final ExerciseRepository exerciseRepository;
+    private final RoutineExerciseService routineExerciseService;
 
     // ID로 사용자 조회 (없으면 예외 발생)
     private User findUserById(int userId) {
@@ -166,5 +167,21 @@ public class RoutineServiceImpl implements RoutineService {
                     return entityToDTO(routine, exercises);
                 })
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public RoutineDTO createRoutineWithExercise(RoutineDTO routineDTO, int userId, int exerciseId, int order) {
+        // 1. 루틴 생성
+        RoutineDTO createdRoutine = createRoutine(routineDTO, userId);
+        // 2. 운동 추가
+        RoutineExerciseDTO exerciseDTO = RoutineExerciseDTO.builder()
+            .routineId(createdRoutine.getId())
+            .exerciseId(exerciseId)
+            .order(order)
+            .build();
+        routineExerciseService.addExerciseToRoutine(exerciseDTO);
+        // 3. 루틴 상세 반환
+        return getRoutineDetails(createdRoutine.getId());
     }
 }


### PR DESCRIPTION
- RoutineController: 신규 루틴 생성+운동 추가 API를 exerciseId 기반으로 반환 
- CreateRoutineWithRecommendedExerciseRequest 추가 : 신규 루틴 생성 + 추천운동(Exercise)을 동시에 추가할 때 사용하는 요청(Request) DTO
- ExerciseService/Impl: getExerciseById 메서드 활용 및 정확한 운동 조회 로직 통일
- AnalysisHistoryDTO/Entity/Service: recommendedExercise 필드 직렬화/역직렬화 및 DTO-Entity 변환 로직 정비
- ExerciseController: 운동명/ID 기반 조회 API 명확화 및 엔드포인트 정비
- ExerciseRepository: findById, findByName 등 쿼리 메서드 명확화
- RoutineService/Impl: createRoutineWithExercise 등 루틴 생성+운동 추가 트랜잭션 로직 개선
- ChatbotController: 분석기록에서 추천운동 추출 시 recommendedExercise 필드 활용하도록 개선
- AiCoachClient: FastAPI 연동 로직 유지
- AnalysisHistoryController: 분석기록 DTO/Entity 변환 및 추천운동 필드 직렬화 일관성 유지